### PR TITLE
Fix sign-in form reset after async submit

### DIFF
--- a/src/app/(transactions)/account/sign-in-form.tsx
+++ b/src/app/(transactions)/account/sign-in-form.tsx
@@ -13,7 +13,8 @@ export function AccountSignInForm() {
 
   async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    const formData = new FormData(event.currentTarget);
+    const form = event.currentTarget;
+    const formData = new FormData(form);
     const email = String(formData.get("email") ?? "").trim();
     const password = String(formData.get("password") ?? "");
 
@@ -33,7 +34,7 @@ export function AccountSignInForm() {
       return;
     }
 
-    event.currentTarget.reset();
+    form.reset();
     setSignedIn(true);
     setPending(false);
     router.replace("/account?welcome=1");


### PR DESCRIPTION
## Summary
- capture the form element before awaiting the async sign-in action
- reset the form via the stored reference to avoid React event pooling issues

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e37b6dcd148321ac90f349241032cc