### PR TITLE
Fix duplicate navigation and footer on account page

### DIFF
--- a/src/app/(transactions)/account/layout.tsx
+++ b/src/app/(transactions)/account/layout.tsx
@@ -1,7 +1,5 @@
 ﻿import type { Metadata } from "next";
 
-import TransactionsLayout from "@/app/(transactions)/layout";
-
 export const metadata: Metadata = {
   title: "Account · Restoran Kiisi",
   description: "Manage your Restoran Kiisi profile, preferences, and reservations.",
@@ -12,5 +10,5 @@ export default function AccountLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return <TransactionsLayout>{children}</TransactionsLayout>;
+  return <>{children}</>;
 }


### PR DESCRIPTION
## Summary
- simplify the account route layout to rely on the shared transactions layout
- prevent duplicate rendering of the site header and footer on the /account page

## Testing
- npm run lint *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68e383ed5f7083219b4005dc6f80808c