### PR TITLE
Adjust time pickers to use 30-minute intervals

### DIFF
--- a/src/app/(transactions)/order/order-form.tsx
+++ b/src/app/(transactions)/order/order-form.tsx
@@ -142,6 +142,7 @@ export function OrderForm({ locations, menuItems }: OrderFormProps) {
           id="requestedReadyAt"
           type="datetime-local"
           className="rounded-lg border border-neutral-200 px-3 py-2 text-sm"
+          step={1800}
           value={requestedTime}
           onChange={(event) => {
             setRequestedTime(event.target.value);

--- a/src/app/(transactions)/reserve/reservation-form.tsx
+++ b/src/app/(transactions)/reserve/reservation-form.tsx
@@ -76,6 +76,7 @@ export function ReservationForm({ locations }: ReservationFormProps) {
           name="requestedTime"
           type="datetime-local"
           data-testid="reservation-datetime"
+          step={1800}
           value={requestedTime}
           onChange={(event) => setRequestedTime(event.target.value)}
           className="rounded-lg border border-neutral-200 px-3 py-2 text-sm"


### PR DESCRIPTION
## Summary
- set the order form "Requested ready at" field to use 30-minute increments
- update the reservation form "Preferred time" selector to match a 30-minute step

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e389ee65e88321bb431475cef47ea6