### PR TITLE
feat: redesign marketing experience with shadcn components

### DIFF
--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -1,8 +1,96 @@
-﻿import { Suspense } from 'react';
-import Link from 'next/link';
+import { Suspense } from "react";
+import Link from "next/link";
 
-import { getLocations, getPromotions } from '@/lib/data';
-import { SkeletonSection } from '@/components/navigation/skeletons';
+import { SkeletonSection } from "@/components/navigation/skeletons";
+import { Badge } from "@/components/ui/badge";
+import { Button, buttonClasses } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { getLocations, getPromotions } from "@/lib/data";
+import { cn } from "@/lib/utils";
+
+const heroHighlights = [
+  {
+    title: "Chef's pairing",
+    description: "Six-course tasting with curated wine journey from Baltic vineyards.",
+  },
+  {
+    title: "Slow mornings",
+    description: "Weekend brunch served 10:00–14:00 with seasonal mocktails.",
+  },
+  {
+    title: "Gatherings",
+    description: "Private dining room for up to 18 guests with bespoke menu design.",
+  },
+];
+
+function HeroSection() {
+  return (
+    <section className="relative overflow-hidden">
+      <div className="absolute inset-0 -z-10">
+        <div className="absolute inset-0 bg-gradient-to-br from-primary/15 via-background to-background" />
+        <div className="absolute left-1/2 top-0 h-[540px] w-[540px] -translate-x-1/2 rounded-full bg-primary/25 blur-3xl" />
+        <div className="absolute bottom-0 right-0 h-64 w-64 translate-x-1/3 translate-y-1/3 rounded-full bg-accent/20 blur-3xl" />
+      </div>
+      <div className="mx-auto flex max-w-6xl flex-col gap-12 px-6 py-24 md:flex-row md:items-center">
+        <div className="flex-1 space-y-8">
+          <Badge variant="subtle" className="w-fit bg-white/70 text-primary shadow-sm backdrop-blur">
+            Tallinn Old Town
+          </Badge>
+          <h1 className="text-balance text-4xl font-semibold tracking-tight text-foreground md:text-6xl">
+            Seasonal Nordic cuisine, plated with warmth.
+          </h1>
+          <p className="text-pretty text-lg text-muted-foreground md:text-xl">
+            From intimate dinners to joyful celebrations, Restoran Kiisi crafts modern Estonian flavours inspired by the
+            Baltic coastline.
+          </p>
+          <div className="flex flex-col gap-3 sm:flex-row">
+            <Link href="/reserve" className={cn(buttonClasses({ size: "lg" }), "shadow-lg shadow-primary/25")}>
+              Reserve a table
+            </Link>
+            <Link
+              href="/menu"
+              className={cn(
+                buttonClasses({ variant: "outline", size: "lg" }),
+                "border-primary/40 bg-white/80 text-primary backdrop-blur transition hover:bg-white",
+              )}
+            >
+              Explore seasonal menu
+            </Link>
+          </div>
+          <dl className="grid gap-4 pt-6 sm:grid-cols-3">
+            {heroHighlights.map((highlight) => (
+              <div
+                key={highlight.title}
+                className="rounded-2xl border border-white/60 bg-white/70 px-5 py-4 text-sm text-muted-foreground shadow-sm backdrop-blur transition hover:border-primary/40 hover:text-foreground"
+              >
+                <dt className="text-xs font-semibold uppercase tracking-[0.18em] text-primary">{highlight.title}</dt>
+                <dd className="mt-2 text-sm leading-6 text-muted-foreground/90">{highlight.description}</dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+        <Card className="flex-1 border-white/70 bg-white/80 shadow-xl backdrop-blur">
+          <CardHeader className="p-8 pb-4">
+            <Badge variant="outline" className="border-primary/40 text-primary">
+              Chef&apos;s note
+            </Badge>
+            <CardTitle className="text-3xl">
+              “We cook with the rhythm of Estonia&apos;s forests, farms, and sea.”
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="p-8 pt-0 text-base leading-7 text-muted-foreground">
+            Our kitchen celebrates low-waste techniques and seasonal produce sourced directly from small regional growers.
+            Each plate is finished with a playful detail to surprise and delight.
+          </CardContent>
+          <CardFooter className="border-0 bg-transparent px-8 pb-8 pt-0 text-sm text-muted-foreground">
+            — Chef Kristel Kiisi
+          </CardFooter>
+        </Card>
+      </div>
+    </section>
+  );
+}
 
 async function PromotionsSection() {
   const promotions = await getPromotions();
@@ -12,37 +100,53 @@ async function PromotionsSection() {
   }
 
   return (
-    <section className="mx-auto max-w-6xl px-6 py-12">
-      <div className="flex items-center justify-between">
-        <h2 className="text-2xl font-semibold">Current offers</h2>
-        <Link href="/offers" className="text-sm text-neutral-500 hover:text-neutral-900">
-          View all
-        </Link>
-      </div>
-      <div className="mt-6 grid gap-6 md:grid-cols-3">
-        {promotions.slice(0, 3).map((promotion) => (
-          <article key={promotion.id} className="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
-            <p className="text-xs uppercase tracking-wide text-neutral-400">
-              {promotion.audience === 'CATERING' ? 'Catering' : 'Signature offer'}
+    <section className="mx-auto max-w-6xl px-6 py-20">
+      <header className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+        <div className="space-y-3">
+          <Badge variant="subtle" className="w-fit bg-primary/10 text-primary">
+            This month in Kiisi
+          </Badge>
+          <div>
+            <h2 className="text-3xl font-semibold tracking-tight text-foreground md:text-4xl">Current experiences</h2>
+            <p className="mt-2 max-w-xl text-pretty text-base text-muted-foreground">
+              Seasonal tastings, family-style feasts, and catering moments curated by Chef Kiisi and the kitchen team.
             </p>
-            <h3 className="mt-2 text-lg font-semibold text-neutral-900">{promotion.title}</h3>
-            {promotion.subtitle ? (
-              <p className="mt-1 text-sm text-neutral-500">{promotion.subtitle}</p>
-            ) : null}
+          </div>
+        </div>
+        <Link
+          href="/offers"
+          className={cn(buttonClasses({ variant: "ghost", size: "default" }), "justify-start md:justify-end")}
+        >
+          View all offers
+        </Link>
+      </header>
+      <div className="mt-10 grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+        {promotions.slice(0, 3).map((promotion) => (
+          <Card key={promotion.id} className="border-border/70 bg-card/90">
+            <CardHeader className="pb-4">
+              <Badge variant="outline" className="border-primary/30 text-xs text-primary">
+                {promotion.audience === "CATERING" ? "Catering" : "Signature experience"}
+              </Badge>
+              <CardTitle className="text-2xl leading-tight">{promotion.title}</CardTitle>
+              {promotion.subtitle ? (
+                <CardDescription className="text-base text-muted-foreground">
+                  {promotion.subtitle}
+                </CardDescription>
+              ) : null}
+            </CardHeader>
             {promotion.body ? (
-              <p className="mt-4 text-sm leading-6 text-neutral-600 line-clamp-4">
-                {promotion.body}
-              </p>
+              <CardContent className="pt-0 text-sm leading-6 text-muted-foreground">
+                <p className="line-clamp-5">{promotion.body}</p>
+              </CardContent>
             ) : null}
             {promotion.ctaUrl ? (
-              <Link
-                href={promotion.ctaUrl}
-                className="mt-4 inline-flex items-center text-sm font-medium text-amber-600 hover:text-amber-700"
-              >
-                {promotion.ctaLabel ?? 'Reserve now'}
-              </Link>
+              <CardFooter className="bg-muted/40">
+                <Link href={promotion.ctaUrl} className={cn(buttonClasses({ variant: "link" }), "text-primary")}>
+                  {promotion.ctaLabel ?? "Reserve now"}
+                </Link>
+              </CardFooter>
             ) : null}
-          </article>
+          </Card>
         ))}
       </div>
     </section>
@@ -53,71 +157,105 @@ async function LocationsSection() {
   const locations = await getLocations();
 
   return (
-    <section className="mx-auto max-w-6xl px-6 py-12">
-      <div className="flex items-center justify-between">
-        <h2 className="text-2xl font-semibold">Visit Restoran Kiisi</h2>
-        <Link href="/locations" className="text-sm text-neutral-500 hover:text-neutral-900">
+    <section className="mx-auto max-w-6xl px-6 pb-24">
+      <header className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+        <div>
+          <Badge variant="subtle" className="w-fit bg-secondary text-secondary-foreground">
+            Around the city
+          </Badge>
+          <h2 className="mt-3 text-3xl font-semibold tracking-tight text-foreground md:text-4xl">
+            Visit Restoran Kiisi
+          </h2>
+          <p className="mt-2 max-w-xl text-pretty text-base text-muted-foreground">
+            Explore our dining rooms across Tallinn—each location carries its own atmosphere, music, and seasonal menu
+            highlights.
+          </p>
+        </div>
+        <Link href="/locations" className={cn(buttonClasses({ variant: "ghost" }), "justify-start md:justify-end")}>
           Find a location
         </Link>
-      </div>
-      <div className="mt-6 grid gap-6 md:grid-cols-3">
+      </header>
+      <div className="mt-10 grid gap-6 md:grid-cols-2 xl:grid-cols-3">
         {locations.map((location) => (
-          <article key={location.id} className="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
-            <h3 className="text-lg font-semibold text-neutral-900">{location.name}</h3>
-            <p className="mt-2 text-sm text-neutral-500">
-              {location.address?.street}
-              <br />
-              {location.address?.city}
-            </p>
-            <p className="mt-4 text-sm text-neutral-500">Open today until 22:00</p>
-            <Link
-              href={`/locations/${location.slug}`}
-              className="mt-6 inline-flex items-center text-sm font-medium text-amber-600 hover:text-amber-700"
-            >
-              View details
-            </Link>
-          </article>
+          <Card key={location.id} className="border-border/70 bg-card/95">
+            <CardHeader className="pb-4">
+              <CardTitle className="text-2xl">{location.name}</CardTitle>
+              <CardDescription>
+                {location.address?.street}
+                <br />
+                {location.address?.city}
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="flex flex-col gap-5 pt-0 text-sm text-muted-foreground">
+              <div>
+                <p className="font-medium text-foreground">Dining style</p>
+                <p>Chef-led tasting menus with vegetarian pairings available.</p>
+              </div>
+              <Separator className="bg-border/60" />
+              <div>
+                <p className="font-medium text-foreground">Today&apos;s service</p>
+                <p>Open from 12:00 – 22:00 with walk-in lounge from 16:00.</p>
+              </div>
+            </CardContent>
+            <CardFooter className="bg-muted/30">
+              <Link href={`/locations/${location.slug}`} className={cn(buttonClasses({ variant: "link" }), "text-primary")}>
+                View details
+              </Link>
+              <Button variant="ghost" size="sm" className="text-xs text-muted-foreground hover:text-foreground">
+                Map &amp; directions
+              </Button>
+            </CardFooter>
+          </Card>
         ))}
       </div>
     </section>
   );
 }
 
-function HeroSection() {
+function CraftSection() {
+  const items = [
+    {
+      title: "Coastal pantry",
+      description: "Dry-aged fish, brined kelp, and foraged sea herbs highlight the flavours of Estonia's shoreline.",
+    },
+    {
+      title: "Cellar pairings",
+      description: "A rotating list of natural wines and local ciders curated with our sommeliers for each seasonal menu.",
+    },
+    {
+      title: "Thoughtful catering",
+      description: "From business lunches to large celebrations, our catering team brings the Kiisi experience to your venue.",
+    },
+  ];
+
   return (
-    <section className="mx-auto flex max-w-6xl flex-col gap-8 px-6 py-16 md:flex-row md:items-center">
-      <div className="flex-1 space-y-6">
-        <span className="rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-amber-700">
-          Tallinn Old Town
-        </span>
-        <h1 className="text-4xl font-semibold tracking-tight md:text-5xl">
-          Seasonal Nordic cuisine, freshly prepared each day.
-        </h1>
-        <p className="text-lg leading-8 text-neutral-600">
-          Browse our rotating menu, place a takeaway order, or reserve a table for your next celebration.
-        </p>
-        <div className="flex flex-col gap-3 sm:flex-row">
-          <Link
-            href="/menu"
-            className="inline-flex items-center justify-center rounded-full bg-amber-600 px-6 py-3 text-sm font-semibold text-white shadow-sm hover:bg-amber-700"
-          >
-            View menu
-          </Link>
-          <Link
-            href="/reserve"
-            className="inline-flex items-center justify-center rounded-full border border-neutral-200 px-6 py-3 text-sm font-semibold text-neutral-900 hover:bg-neutral-100"
-          >
-            Reserve a table
-          </Link>
+    <section className="mx-auto max-w-6xl px-6 pb-20">
+      <div className="relative overflow-hidden rounded-[2.5rem] border border-border/70 bg-gradient-to-r from-secondary/60 via-background to-background p-[1px] shadow-xl">
+        <div className="rounded-[2.45rem] bg-white/80 px-8 py-16 backdrop-blur md:px-14">
+          <div className="mx-auto max-w-3xl text-center">
+            <Badge variant="subtle" className="mx-auto mb-4 w-fit bg-accent/10 text-accent">
+              The Kiisi craft
+            </Badge>
+            <h2 className="text-balance text-3xl font-semibold tracking-tight text-foreground md:text-4xl">
+              Every course is an invitation to linger.
+            </h2>
+            <p className="mt-4 text-pretty text-base text-muted-foreground md:text-lg">
+              We design dining journeys that begin with a warm welcome, continue with thoughtful pacing, and finish with a gentle finale.
+            </p>
+          </div>
+          <div className="mt-12 grid gap-6 md:grid-cols-3">
+            {items.map((item) => (
+              <div
+                key={item.title}
+                className="rounded-3xl border border-border/60 bg-white/70 p-6 text-left shadow-sm backdrop-blur transition hover:-translate-y-1 hover:shadow-md"
+              >
+                <div className="mb-4 h-12 w-12 rounded-2xl bg-primary/10" />
+                <h3 className="text-xl font-semibold text-foreground">{item.title}</h3>
+                <p className="mt-3 text-sm leading-6 text-muted-foreground">{item.description}</p>
+              </div>
+            ))}
+          </div>
         </div>
-      </div>
-      <div className="flex-1 rounded-3xl border border-neutral-200 bg-white p-8 shadow-sm">
-        <p className="text-sm font-semibold text-amber-600">Chef&apos;s note</p>
-        <p className="mt-4 text-lg leading-8 text-neutral-600">
-          “Restoran Kiisi is inspired by the forests and coastline surrounding Tallinn. Our kitchen focuses on
-          low-waste techniques and seasonal ingredients from local producers.”
-        </p>
-        <p className="mt-6 text-sm text-neutral-500">— Chef Kristel Kiisi</p>
       </div>
     </section>
   );
@@ -130,10 +268,10 @@ export default function MarketingHomePage() {
       <Suspense fallback={<SkeletonSection />}>
         <PromotionsSection />
       </Suspense>
+      <CraftSection />
       <Suspense fallback={<SkeletonSection />}>
         <LocationsSection />
       </Suspense>
     </div>
   );
 }
-

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,26 +1,109 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
-}
-
-@theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --background: 42 47% 97%;
+  --foreground: 24 14% 12%;
+  --muted: 36 41% 92%;
+  --muted-foreground: 25 11% 36%;
+  --card: 0 0% 100%;
+  --card-foreground: 24 14% 12%;
+  --popover: 0 0% 100%;
+  --popover-foreground: 24 14% 12%;
+  --border: 30 24% 88%;
+  --input: 30 24% 88%;
+  --primary: 26 96% 47%;
+  --primary-foreground: 45 100% 98%;
+  --secondary: 35 70% 94%;
+  --secondary-foreground: 24 16% 28%;
+  --accent: 189 75% 43%;
+  --accent-foreground: 195 100% 97%;
+  --destructive: 4 88% 58%;
+  --destructive-foreground: 0 0% 98%;
+  --ring: 26 96% 47%;
+  --radius-xs: 0.75rem;
+  --radius-sm: 1.1rem;
+  --radius: 1.5rem;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
+    --background: 30 20% 6%;
+    --foreground: 35 35% 96%;
+    --muted: 28 21% 16%;
+    --muted-foreground: 36 17% 70%;
+    --card: 28 18% 12%;
+    --card-foreground: 35 35% 96%;
+    --popover: 28 18% 12%;
+    --popover-foreground: 35 35% 96%;
+    --border: 28 18% 18%;
+    --input: 28 18% 18%;
+    --primary: 30 92% 63%;
+    --primary-foreground: 28 22% 8%;
+    --secondary: 22 26% 21%;
+    --secondary-foreground: 36 24% 88%;
+    --accent: 194 84% 62%;
+    --accent-foreground: 209 100% 12%;
+    --destructive: 0 86% 67%;
+    --destructive-foreground: 24 12% 10%;
+    --ring: 30 92% 63%;
   }
 }
 
-body {
-  background: var(--background);
-  color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+@theme inline {
+  --color-background: hsl(var(--background));
+  --color-foreground: hsl(var(--foreground));
+  --color-muted: hsl(var(--muted));
+  --color-muted-foreground: hsl(var(--muted-foreground));
+  --color-card: hsl(var(--card));
+  --color-card-foreground: hsl(var(--card-foreground));
+  --color-popover: hsl(var(--popover));
+  --color-popover-foreground: hsl(var(--popover-foreground));
+  --color-border: hsl(var(--border));
+  --color-input: hsl(var(--input));
+  --color-primary: hsl(var(--primary));
+  --color-primary-foreground: hsl(var(--primary-foreground));
+  --color-secondary: hsl(var(--secondary));
+  --color-secondary-foreground: hsl(var(--secondary-foreground));
+  --color-accent: hsl(var(--accent));
+  --color-accent-foreground: hsl(var(--accent-foreground));
+  --color-destructive: hsl(var(--destructive));
+  --color-destructive-foreground: hsl(var(--destructive-foreground));
+  --color-ring: hsl(var(--ring));
+  --radius-sm: var(--radius-xs);
+  --radius: var(--radius);
+  --radius-lg: calc(var(--radius) + 0.75rem);
+  --font-sans: var(--font-geist-sans);
+  --font-mono: var(--font-geist-mono);
+}
+
+@layer base {
+  *,
+  *::before,
+  *::after {
+    border-color: hsl(var(--border));
+  }
+
+  body {
+    font-family: var(--font-sans);
+    background-color: hsl(var(--background));
+    color: hsl(var(--foreground));
+    min-height: 100vh;
+    letter-spacing: -0.01em;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    color: hsl(var(--foreground));
+    font-weight: 600;
+    letter-spacing: -0.02em;
+  }
+
+  ::selection {
+    background-color: hsl(var(--accent));
+    color: hsl(var(--accent-foreground));
+  }
 }

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,27 @@
+import type { HTMLAttributes } from "react";
+import { cn } from "@/lib/utils";
+
+type BadgeVariant = "default" | "outline" | "subtle";
+
+const variantStyles: Record<BadgeVariant, string> = {
+  default: "bg-primary/15 text-primary ring-1 ring-primary/20",
+  outline: "border border-border text-muted-foreground",
+  subtle: "bg-muted text-muted-foreground",
+};
+
+export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
+  variant?: BadgeVariant;
+}
+
+export function Badge({ className, variant = "default", ...props }: BadgeProps) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs font-medium uppercase tracking-[0.12em]",
+        variantStyles[variant],
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,54 @@
+import type { ButtonHTMLAttributes } from "react";
+import { cn } from "@/lib/utils";
+
+type ButtonVariant = "default" | "secondary" | "outline" | "ghost" | "link";
+type ButtonSize = "sm" | "default" | "lg" | "icon";
+
+const baseStyles =
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-full text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-60 focus-visible:ring-offset-background";
+
+const variantStyles: Record<ButtonVariant, string> = {
+  default: "bg-primary text-primary-foreground shadow-sm hover:bg-primary/90",
+  secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+  outline: "border border-input bg-background text-foreground hover:bg-muted hover:text-foreground",
+  ghost: "text-muted-foreground hover:bg-muted hover:text-foreground",
+  link: "text-primary underline-offset-4 hover:text-primary/80 hover:underline",
+};
+
+const sizeStyles: Record<ButtonSize, string> = {
+  sm: "h-9 px-4 text-xs",
+  default: "h-11 px-6",
+  lg: "h-12 px-8 text-base",
+  icon: "h-10 w-10",
+};
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+}
+
+export function buttonClasses({
+  variant = "default",
+  size = "default",
+}: {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+} = {}) {
+  return cn(baseStyles, variantStyles[variant], sizeStyles[size]);
+}
+
+export function Button({
+  className,
+  variant = "default",
+  size = "default",
+  type = "button",
+  ...props
+}: ButtonProps) {
+  return (
+    <button
+      type={type}
+      className={cn(buttonClasses({ variant, size }), className)}
+      {...props}
+    />
+  );
+}

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,46 @@
+import type { HTMLAttributes } from "react";
+import { cn } from "@/lib/utils";
+
+export interface CardProps extends HTMLAttributes<HTMLDivElement> {}
+
+export function Card({ className, ...props }: CardProps) {
+  return (
+    <div
+      className={cn(
+        "group relative overflow-hidden rounded-3xl border border-border/80 bg-card shadow-lg shadow-black/5 transition hover:-translate-y-1 hover:shadow-xl",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export interface CardContentProps extends HTMLAttributes<HTMLDivElement> {}
+
+export function CardContent({ className, ...props }: CardContentProps) {
+  return <div className={cn("space-y-4 p-8", className)} {...props} />;
+}
+
+export interface CardHeaderProps extends HTMLAttributes<HTMLDivElement> {}
+
+export function CardHeader({ className, ...props }: CardHeaderProps) {
+  return <div className={cn("space-y-2 p-8", className)} {...props} />;
+}
+
+export interface CardTitleProps extends HTMLAttributes<HTMLHeadingElement> {}
+
+export function CardTitle({ className, ...props }: CardTitleProps) {
+  return <h3 className={cn("text-2xl font-semibold tracking-tight text-foreground", className)} {...props} />;
+}
+
+export interface CardDescriptionProps extends HTMLAttributes<HTMLParagraphElement> {}
+
+export function CardDescription({ className, ...props }: CardDescriptionProps) {
+  return <p className={cn("text-sm text-muted-foreground", className)} {...props} />;
+}
+
+export interface CardFooterProps extends HTMLAttributes<HTMLDivElement> {}
+
+export function CardFooter({ className, ...props }: CardFooterProps) {
+  return <div className={cn("flex items-center justify-between gap-2 border-t border-border/60 bg-muted/30 px-8 py-5", className)} {...props} />;
+}

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,0 +1,21 @@
+import type { HTMLAttributes } from "react";
+import { cn } from "@/lib/utils";
+
+export interface SeparatorProps extends HTMLAttributes<HTMLDivElement> {
+  orientation?: "horizontal" | "vertical";
+}
+
+export function Separator({ orientation = "horizontal", className, ...props }: SeparatorProps) {
+  return (
+    <div
+      role="separator"
+      aria-orientation={orientation}
+      className={cn(
+        "bg-border/80",
+        orientation === "horizontal" ? "h-px w-full" : "h-full w-px",
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,49 @@
+export type ClassValue =
+  | string
+  | number
+  | null
+  | undefined
+  | false
+  | ClassValue[]
+  | { [key: string]: boolean | string | number | null | undefined | false };
+
+function toClassList(value: ClassValue, classes: string[]) {
+  if (!value) {
+    return;
+  }
+
+  if (typeof value === "string" || typeof value === "number") {
+    const normalized = String(value).trim();
+    if (normalized) {
+      classes.push(normalized);
+    }
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      toClassList(entry, classes);
+    }
+    return;
+  }
+
+  if (typeof value === "object") {
+    for (const [key, condition] of Object.entries(value)) {
+      if (condition) {
+        classes.push(key);
+      }
+    }
+  }
+}
+
+export function cn(...inputs: ClassValue[]): string {
+  const classes: string[] = [];
+  for (const input of inputs) {
+    toClassList(input, classes);
+  }
+  return classes.join(" ").replace(/\s+/g, " ").trim();
+}
+
+export function compact<T>(value: (T | null | undefined)[]): T[] {
+  return value.filter((item): item is T => item !== null && item !== undefined);
+}


### PR DESCRIPTION
## Summary
- update the global design tokens and base styles to support a shadcn-inspired theme
- add reusable badge, button, card, and separator primitives along with a class-merging utility
- refresh the marketing landing page with new hero, promotions, craft, and location sections using the new UI primitives

## Testing
- npm run lint *(fails: Cannot find package '@eslint/eslintrc' in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e393a7fa808321aa0b144128c98147