### PR TITLE
feat: refresh marketing surfaces with shadcn patterns

### DIFF
--- a/src/app/(marketing)/careers/page.tsx
+++ b/src/app/(marketing)/careers/page.tsx
@@ -1,97 +1,162 @@
+import { Badge } from "@/components/ui/badge";
+import { buttonClasses } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { cn } from "@/lib/utils";
+
+const teams = [
+  {
+    name: "Kitchen",
+    badge: "Back of house",
+    roles: [
+      {
+        title: "Sous Chef",
+        description: "Lead our kitchen brigade in crafting innovative seasonal tasting menus.",
+        details: "Full-time • Tallinn Old Town",
+      },
+      {
+        title: "Line Cook",
+        description: "Execute dishes with precision during busy evening services.",
+        details: "Full-time • Tallinn Old Town",
+      },
+    ],
+  },
+  {
+    name: "Front of house",
+    badge: "Guest experience",
+    roles: [
+      {
+        title: "Server",
+        description: "Deliver thoughtful service with deep menu and wine knowledge.",
+        details: "Part-time / Full-time • Tallinn Old Town",
+      },
+      {
+        title: "Host",
+        description: "Welcome guests, orchestrate reservations, and set the tone for the evening.",
+        details: "Part-time • Tallinn Old Town",
+      },
+    ],
+  },
+];
+
+const benefits = [
+  "Competitive salary, tips, and performance recognition",
+  "Flexible scheduling tailored to work-life balance",
+  "Family meal every shift and generous dining discounts",
+  "Workshops with guest chefs, sommeliers, and producers",
+  "Pathways for progression within the Kiisi group",
+  "Wellness support including staff yoga and counselling",
+];
+
 export default function CareersPage() {
   return (
-    <div className="mx-auto max-w-4xl space-y-8 px-6 py-12">
-      <header className="space-y-2">
-        <h1 className="text-3xl font-semibold text-neutral-900">Careers</h1>
-        <p className="text-sm text-neutral-500">
-          Join our passionate team and help us create exceptional dining experiences in Tallinn.
-        </p>
-      </header>
-
-      <div className="space-y-8">
-        <div className="space-y-4">
-          <h2 className="text-xl font-semibold text-neutral-900">Why Work at Restoran Kiisi?</h2>
-          <p className="text-sm text-neutral-600">
-            At Restoran Kiisi, we believe that great food comes from great people. We're looking for 
-            passionate individuals who share our commitment to excellence, creativity, and authentic 
-            Estonian cuisine.
+    <div className="mx-auto max-w-5xl space-y-16 px-6 py-16">
+      <section className="space-y-6 text-center md:text-left">
+        <Badge className="mx-auto md:mx-0" variant="outline">
+          Join the Kiisi family
+        </Badge>
+        <div className="space-y-3">
+          <h1 className="text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">Careers</h1>
+          <p className="text-base text-muted-foreground md:max-w-2xl">
+            We believe in nurturing talent, celebrating curiosity, and creating spaces where both guests and team members feel at home.
           </p>
         </div>
-
-        <div className="grid gap-6 md:grid-cols-2">
-          <div className="space-y-4">
-            <h3 className="text-lg font-semibold text-neutral-900">Kitchen Positions</h3>
-            <div className="space-y-3">
-              <div className="rounded-lg border border-neutral-200 bg-white p-4 shadow-sm">
-                <h4 className="font-semibold text-neutral-900">Sous Chef</h4>
-                <p className="text-sm text-neutral-600 mt-1">Lead our kitchen team in creating innovative seasonal dishes</p>
-                <p className="text-xs text-neutral-500 mt-2">Full-time • Tallinn Old Town</p>
-              </div>
-              <div className="rounded-lg border border-neutral-200 bg-white p-4 shadow-sm">
-                <h4 className="font-semibold text-neutral-900">Line Cook</h4>
-                <p className="text-sm text-neutral-600 mt-1">Prepare and plate dishes in our fast-paced kitchen environment</p>
-                <p className="text-xs text-neutral-500 mt-2">Full-time • Tallinn Old Town</p>
-              </div>
-            </div>
-          </div>
-
-          <div className="space-y-4">
-            <h3 className="text-lg font-semibold text-neutral-900">Front of House</h3>
-            <div className="space-y-3">
-              <div className="rounded-lg border border-neutral-200 bg-white p-4 shadow-sm">
-                <h4 className="font-semibold text-neutral-900">Server</h4>
-                <p className="text-sm text-neutral-600 mt-1">Provide exceptional service and create memorable dining experiences</p>
-                <p className="text-xs text-neutral-500 mt-2">Part-time/Full-time • Tallinn Old Town</p>
-              </div>
-              <div className="rounded-lg border border-neutral-200 bg-white p-4 shadow-sm">
-                <h4 className="font-semibold text-neutral-900">Host/Hostess</h4>
-                <p className="text-sm text-neutral-600 mt-1">Welcome guests and manage reservations in our warm atmosphere</p>
-                <p className="text-xs text-neutral-500 mt-2">Part-time • Tallinn Old Town</p>
-              </div>
-            </div>
-          </div>
+        <div className="flex flex-col items-center gap-3 text-sm text-muted-foreground md:flex-row md:items-center">
+          <span className="font-medium text-foreground">We&apos;re always excited to meet new talent.</span>
+          <span className="rounded-full bg-muted px-4 py-1">Applications reviewed weekly.</span>
         </div>
+      </section>
 
-        <div className="space-y-4">
-          <h2 className="text-xl font-semibold text-neutral-900">Benefits & Perks</h2>
-          <div className="grid gap-4 md:grid-cols-2">
-            <ul className="space-y-2 text-sm text-neutral-600">
-              <li>• Competitive salary and tips</li>
-              <li>• Flexible scheduling</li>
-              <li>• Staff meals and discounts</li>
-              <li>• Professional development opportunities</li>
+      <section className="grid gap-6 md:grid-cols-2">
+        {teams.map((team) => (
+          <Card key={team.name} className="h-full">
+            <CardHeader className="space-y-4">
+              <Badge>{team.badge}</Badge>
+              <CardTitle>{team.name}</CardTitle>
+              <CardDescription>
+                {team.name === "Kitchen"
+                  ? "Craft dishes that honour Estonian ingredients and progressive techniques."
+                  : "Deliver hospitality with heart in our historic Old Town dining room."}
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {team.roles.map((role) => (
+                <div
+                  key={role.title}
+                  className="rounded-2xl border border-border/60 bg-muted/20 p-4 transition hover:border-border hover:bg-muted/40"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="space-y-1">
+                      <h3 className="text-base font-semibold text-foreground">{role.title}</h3>
+                      <p className="text-sm text-muted-foreground">{role.description}</p>
+                    </div>
+                    <Badge variant="subtle">Hiring</Badge>
+                  </div>
+                  <p className="mt-3 text-xs uppercase tracking-[0.12em] text-muted-foreground">{role.details}</p>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+        ))}
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-[1.1fr,1fr]">
+        <Card className="h-full">
+          <CardHeader className="space-y-4">
+            <Badge variant="subtle">Benefits</Badge>
+            <CardTitle>Why you&apos;ll love working here</CardTitle>
+            <CardDescription>
+              Our team enjoys thoughtful support, ongoing education, and opportunities to grow with the restaurant.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ul className="space-y-3 text-sm text-muted-foreground">
+              {benefits.map((benefit) => (
+                <li key={benefit} className="flex items-start gap-2">
+                  <span className="mt-1 h-1.5 w-1.5 rounded-full bg-primary" aria-hidden />
+                  <span>{benefit}</span>
+                </li>
+              ))}
             </ul>
-            <ul className="space-y-2 text-sm text-neutral-600">
-              <li>• Collaborative team environment</li>
-              <li>• Opportunities for growth</li>
-              <li>• Health and wellness benefits</li>
-              <li>• Employee recognition programs</li>
-            </ul>
-          </div>
-        </div>
-
-        <div className="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
-          <h2 className="text-xl font-semibold text-neutral-900 mb-4">Apply Today</h2>
-          <p className="text-sm text-neutral-600 mb-6">
-            Ready to join our team? Send us your resume and cover letter, or stop by the restaurant 
-            to speak with our manager about current opportunities.
-          </p>
-          <div className="flex flex-col gap-4 sm:flex-row">
-            <a
-              href="/contact"
-              className="inline-flex items-center justify-center rounded-full bg-amber-600 px-6 py-3 text-sm font-semibold text-white shadow-sm hover:bg-amber-700"
-            >
-              Apply Online
-            </a>
-            <a
-              href="tel:+37255512345"
-              className="inline-flex items-center justify-center rounded-full border border-amber-600 px-6 py-3 text-sm font-semibold text-amber-600 hover:bg-amber-50"
-            >
-              Call +372 555 12345
-            </a>
-          </div>
-        </div>
-      </div>
+          </CardContent>
+        </Card>
+        <Card className="h-full">
+          <CardHeader className="space-y-4">
+            <Badge variant="outline">Apply</Badge>
+            <CardTitle>Ready to join?</CardTitle>
+            <CardDescription>
+              Share your CV, tell us about your favourite ingredient, and we&apos;ll be in touch to arrange a conversation.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6 text-sm text-muted-foreground">
+            <p>
+              Email
+              <a href="mailto:careers@restorankiisi.ee" className="font-medium text-primary">
+                &nbsp;careers@restorankiisi.ee
+              </a>
+              &nbsp;or visit us between 15:00 and 17:00 on weekdays to meet the team.
+            </p>
+            <Separator />
+            <div className="flex flex-col gap-3 sm:flex-row">
+              <a href="/contact" className={cn(buttonClasses(), "flex-1 justify-center")}>
+                Apply online
+              </a>
+              <a
+                href="tel:+37255512345"
+                className={cn(buttonClasses({ variant: "outline" }), "flex-1 justify-center")}
+              >
+                Call +372 555 12345
+              </a>
+            </div>
+          </CardContent>
+        </Card>
+      </section>
     </div>
   );
 }

--- a/src/app/(marketing)/catering/page.tsx
+++ b/src/app/(marketing)/catering/page.tsx
@@ -1,63 +1,210 @@
+import { Badge } from "@/components/ui/badge";
+import { buttonClasses } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { cn } from "@/lib/utils";
+
+const services = [
+  {
+    title: "Corporate gatherings",
+    tag: "Business",
+    description:
+      "Boardroom lunches, press events, and brand launches with discreet service and polished presentation.",
+    highlights: [
+      "Seasonally rotating menus tailored to your agenda",
+      "Dedicated event lead for seamless logistics",
+      "Service staff, tableware, and styling included",
+      "Dietary accommodations prepared with advance notice",
+    ],
+  },
+  {
+    title: "Private celebrations",
+    tag: "Celebration",
+    description:
+      "Milestone birthdays, intimate weddings, and anniversaries designed around your story and favourite flavours.",
+    highlights: [
+      "Menu consultation with our head chef",
+      "Wine pairing guidance from our sommelier team",
+      "Flexible service formats—from plated to family-style",
+      "Delivery and on-site finishing within Tallinn and Harju County",
+    ],
+  },
+];
+
+const packages = [
+  {
+    name: "Canapé reception",
+    description: "Elegant standing event with curated bites",
+    details: [
+      "Up to 60 guests",
+      "Twelve seasonal canapés",
+      "Signature welcome cocktail",
+      "Two-hour service team",
+    ],
+  },
+  {
+    name: "Chef’s table",
+    description: "Seven-course plated tasting with wine pairings",
+    details: [
+      "Up to 24 guests",
+      "Tableside storytelling by our chefs",
+      "Sommelier-selected pairing menu",
+      "Printed menus for each guest",
+    ],
+  },
+  {
+    name: "Weekend retreat",
+    description: "Multi-day experience with breakfast, lunch, and dinner",
+    details: [
+      "Up to 40 guests",
+      "Interactive cooking workshop",
+      "Cellar tasting experience",
+      "On-site service captain",
+    ],
+  },
+];
+
 export default function CateringPage() {
   return (
-    <div className="mx-auto max-w-4xl space-y-8 px-6 py-12">
-      <header className="space-y-2">
-        <h1 className="text-3xl font-semibold text-neutral-900">Catering Services</h1>
-        <p className="text-sm text-neutral-500">
-          Bring the authentic flavors of Restoran Kiisi to your special events and gatherings.
-        </p>
-      </header>
-
-      <div className="grid gap-8 md:grid-cols-2">
-        <div className="space-y-4">
-          <h2 className="text-xl font-semibold text-neutral-900">Corporate Events</h2>
-          <p className="text-sm text-neutral-600">
-            Professional catering for business meetings, conferences, and corporate celebrations. 
-            We provide everything from intimate boardroom lunches to large-scale company events.
+    <div className="mx-auto max-w-5xl space-y-16 px-6 py-16">
+      <section className="space-y-6 text-center md:text-left">
+        <Badge className="mx-auto md:mx-0" variant="outline">
+          From our kitchen to yours
+        </Badge>
+        <div className="space-y-3">
+          <h1 className="text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">Catering services</h1>
+          <p className="text-base text-muted-foreground md:max-w-2xl">
+            Elevate your gathering with considered flavours, artful presentation, and hospitality delivered by the
+            Restoran Kiisi events team.
           </p>
-          <ul className="space-y-2 text-sm text-neutral-600">
-            <li>• Custom menu planning</li>
-            <li>• Professional service staff</li>
-            <li>• Dietary accommodation</li>
-            <li>• Setup and cleanup included</li>
-          </ul>
         </div>
+        <div className="flex flex-col items-center gap-3 text-sm text-muted-foreground md:flex-row md:items-center">
+          <span className="font-medium text-foreground">Planning something bespoke?</span>
+          <span className="rounded-full bg-muted px-4 py-1">We respond within one business day.</span>
+        </div>
+      </section>
 
-        <div className="space-y-4">
-          <h2 className="text-xl font-semibold text-neutral-900">Private Celebrations</h2>
-          <p className="text-sm text-neutral-600">
-            Make your special occasions memorable with our signature dishes. From birthday parties 
-            to anniversary dinners, we create personalized experiences for your guests.
-          </p>
-          <ul className="space-y-2 text-sm text-neutral-600">
-            <li>• Personalized menu consultation</li>
-            <li>• Seasonal ingredient focus</li>
-            <li>• Flexible serving options</li>
-            <li>• Local delivery available</li>
-          </ul>
-        </div>
-      </div>
+      <section className="grid gap-6 md:grid-cols-2">
+        {services.map((service) => (
+          <Card key={service.title} className="h-full">
+            <CardHeader className="space-y-4">
+              <Badge>{service.tag}</Badge>
+              <CardTitle>{service.title}</CardTitle>
+              <CardDescription>{service.description}</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ul className="space-y-3 text-sm text-muted-foreground">
+                {service.highlights.map((highlight) => (
+                  <li key={highlight} className="flex items-start gap-2">
+                    <span className="mt-1 h-1.5 w-1.5 rounded-full bg-primary" aria-hidden />
+                    <span>{highlight}</span>
+                  </li>
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
+        ))}
+      </section>
 
-      <div className="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
-        <h2 className="text-xl font-semibold text-neutral-900 mb-4">Get Started</h2>
-        <p className="text-sm text-neutral-600 mb-6">
-          Ready to plan your event? Contact our catering team to discuss your needs and receive a custom quote.
-        </p>
-        <div className="flex flex-col gap-4 sm:flex-row">
-          <a
-            href="/contact"
-            className="inline-flex items-center justify-center rounded-full bg-amber-600 px-6 py-3 text-sm font-semibold text-white shadow-sm hover:bg-amber-700"
-          >
-            Contact Catering Team
-          </a>
-          <a
-            href="tel:+37255512345"
-            className="inline-flex items-center justify-center rounded-full border border-amber-600 px-6 py-3 text-sm font-semibold text-amber-600 hover:bg-amber-50"
-          >
-            Call +372 555 12345
-          </a>
+      <section className="space-y-6">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h2 className="text-2xl font-semibold tracking-tight text-foreground">Signature packages</h2>
+            <p className="text-sm text-muted-foreground">
+              Curated culinary journeys designed for a variety of guest counts and atmospheres.
+            </p>
+          </div>
+          <Badge variant="subtle">Custom menus available</Badge>
         </div>
-      </div>
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {packages.map((pkg) => (
+            <Card key={pkg.name}>
+              <CardHeader className="space-y-2">
+                <CardTitle className="text-xl">{pkg.name}</CardTitle>
+                <CardDescription>{pkg.description}</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <ul className="space-y-2 text-sm text-muted-foreground">
+                  {pkg.details.map((detail) => (
+                    <li key={detail} className="flex items-start gap-2">
+                      <span className="mt-1 h-1.5 w-1.5 rounded-full bg-primary" aria-hidden />
+                      <span>{detail}</span>
+                    </li>
+                  ))}
+                </ul>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-[1.1fr,1fr]">
+        <Card className="h-full">
+          <CardHeader className="space-y-4">
+            <Badge variant="subtle">Let&apos;s collaborate</Badge>
+            <CardTitle>Start planning</CardTitle>
+            <CardDescription>
+              Share your event vision and we&apos;ll prepare a tailored proposal complete with timelines, staffing, and menu flow.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div className="flex flex-col gap-3 sm:flex-row">
+              <a href="/contact" className={cn(buttonClasses(), "flex-1 justify-center")}>
+                Contact catering team
+              </a>
+              <a
+                href="tel:+37255512345"
+                className={cn(buttonClasses({ variant: "outline" }), "flex-1 justify-center")}
+              >
+                Call +372 555 12345
+              </a>
+            </div>
+            <p className="text-sm text-muted-foreground">
+              Include your preferred date, guest count, and location—we&apos;ll confirm availability and schedule a consultation.
+            </p>
+          </CardContent>
+        </Card>
+        <Card className="h-full">
+          <CardHeader className="space-y-4">
+            <Badge variant="outline">Enhancements</Badge>
+            <CardTitle>Additional experiences</CardTitle>
+            <CardDescription>
+              Extend the celebration with wine tastings, chef-led workshops, or bespoke styling elements.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4 text-sm text-muted-foreground">
+            <p>Popular additions include:</p>
+            <ul className="space-y-3">
+              <li className="flex items-start gap-2">
+                <span className="mt-1 h-1.5 w-1.5 rounded-full bg-primary" aria-hidden />
+                <span>Nordic spirits pairing bar with seasonal infusions</span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 h-1.5 w-1.5 rounded-full bg-primary" aria-hidden />
+                <span>Interactive rye bread workshop hosted by our bakers</span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 h-1.5 w-1.5 rounded-full bg-primary" aria-hidden />
+                <span>Floral styling and tablescape curation in partnership with local artisans</span>
+              </li>
+            </ul>
+            <Separator />
+            <p>
+              Looking for something unexpected? Email
+              <a href="mailto:events@restorankiisi.ee" className="font-medium text-primary">
+                &nbsp;events@restorankiisi.ee
+              </a>
+              &nbsp;and we&apos;ll craft a concept just for you.
+            </p>
+          </CardContent>
+        </Card>
+      </section>
     </div>
   );
 }

--- a/src/app/(marketing)/events/page.tsx
+++ b/src/app/(marketing)/events/page.tsx
@@ -1,101 +1,193 @@
+import { Badge } from "@/components/ui/badge";
+import { buttonClasses } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { cn } from "@/lib/utils";
+
+const venues = [
+  {
+    name: "Private dining room",
+    badge: "12 guests",
+    description:
+      "An intimate oak-panelled room for tastings, anniversaries, and executive dinners with curated playlists and lighting.",
+    highlights: [
+      "Custom tasting menu with optional wine pairings",
+      "Dedicated service team and sommelier",
+      "Pre-arrival styling and personalised menus",
+      "Discreet AV setup for presentations",
+    ],
+  },
+  {
+    name: "Restaurant buyout",
+    badge: "40 guests",
+    description:
+      "Transform the entire restaurant into your stage for milestone celebrations, launches, or festive gatherings.",
+    highlights: [
+      "Flexible floor plan with lounge and dining zones",
+      "Live music or DJ coordination",
+      "Signature cocktail and bar programming",
+      "Late-night dessert table or midnight snack bar",
+    ],
+  },
+];
+
+const eventPackages = [
+  {
+    title: "Intimate gathering",
+    description: "A warm celebration over a curated three-course menu",
+    features: ["Up to 8 guests", "Welcome sparkling wine", "Three-course seasonal menu", "Keepsake menu cards"],
+  },
+  {
+    title: "Chef’s tasting",
+    description: "Immersive five-course tasting crafted by our culinary team",
+    features: ["Up to 12 guests", "Five-course menu with storytelling", "Sommelier wine pairing", "Floral tablescape"],
+  },
+  {
+    title: "Signature soirée",
+    description: "Exclusive restaurant experience with live entertainment",
+    features: ["Up to 40 guests", "Custom food and beverage stations", "Full venue styling", "Event concierge on-site"],
+  },
+];
+
 export default function EventsPage() {
   return (
-    <div className="mx-auto max-w-4xl space-y-8 px-6 py-12">
-      <header className="space-y-2">
-        <h1 className="text-3xl font-semibold text-neutral-900">Private Events</h1>
-        <p className="text-sm text-neutral-500">
-          Host your special occasions in the intimate atmosphere of Restoran Kiisi.
-        </p>
-      </header>
-
-      <div className="grid gap-8 md:grid-cols-2">
-        <div className="space-y-4">
-          <h2 className="text-xl font-semibold text-neutral-900">Private Dining</h2>
-          <p className="text-sm text-neutral-600">
-            Reserve our private dining room for intimate gatherings of up to 12 guests. 
-            Enjoy personalized service and a curated menu in an exclusive setting.
+    <div className="mx-auto max-w-5xl space-y-16 px-6 py-16">
+      <section className="space-y-6 text-center md:text-left">
+        <Badge className="mx-auto md:mx-0" variant="outline">
+          Celebrate at Kiisi
+        </Badge>
+        <div className="space-y-3">
+          <h1 className="text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">Private events</h1>
+          <p className="text-base text-muted-foreground md:max-w-2xl">
+            From intimate gatherings to full restaurant soirées, our team choreographs every detail so you can be fully present with your guests.
           </p>
-          <ul className="space-y-2 text-sm text-neutral-600">
-            <li>• Seating for 8-12 guests</li>
-            <li>• Custom tasting menu</li>
-            <li>• Wine pairing recommendations</li>
-            <li>• Dedicated service staff</li>
-          </ul>
         </div>
-
-        <div className="space-y-4">
-          <h2 className="text-xl font-semibold text-neutral-900">Restaurant Buyout</h2>
-          <p className="text-sm text-neutral-600">
-            Take over the entire restaurant for larger celebrations. Perfect for milestone 
-            birthdays, engagement parties, or corporate dinners.
-          </p>
-          <ul className="space-y-2 text-sm text-neutral-600">
-            <li>• Full restaurant capacity (40 guests)</li>
-            <li>• Exclusive use of the space</li>
-            <li>• Custom event planning</li>
-            <li>• Flexible timing options</li>
-          </ul>
+        <div className="flex flex-col items-center gap-3 text-sm text-muted-foreground md:flex-row md:items-center">
+          <span className="font-medium text-foreground">Let&apos;s design something unforgettable.</span>
+          <span className="rounded-full bg-muted px-4 py-1">Event proposals delivered within 48 hours.</span>
         </div>
-      </div>
+      </section>
 
-      <div className="space-y-6">
-        <h2 className="text-xl font-semibold text-neutral-900">Event Packages</h2>
-        <div className="grid gap-6 md:grid-cols-3">
-          <div className="rounded-lg border border-neutral-200 bg-white p-4 shadow-sm">
-            <h3 className="font-semibold text-neutral-900 mb-2">Intimate Gathering</h3>
-            <p className="text-sm text-neutral-600 mb-3">Perfect for small celebrations</p>
-            <ul className="space-y-1 text-xs text-neutral-600">
-              <li>• Up to 8 guests</li>
-              <li>• 3-course menu</li>
-              <li>• Wine selection</li>
-              <li>• 3-hour reservation</li>
-            </ul>
+      <section className="grid gap-6 md:grid-cols-2">
+        {venues.map((venue) => (
+          <Card key={venue.name} className="h-full">
+            <CardHeader className="space-y-4">
+              <Badge>{venue.badge}</Badge>
+              <CardTitle>{venue.name}</CardTitle>
+              <CardDescription>{venue.description}</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ul className="space-y-3 text-sm text-muted-foreground">
+                {venue.highlights.map((highlight) => (
+                  <li key={highlight} className="flex items-start gap-2">
+                    <span className="mt-1 h-1.5 w-1.5 rounded-full bg-primary" aria-hidden />
+                    <span>{highlight}</span>
+                  </li>
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
+        ))}
+      </section>
+
+      <section className="space-y-6">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h2 className="text-2xl font-semibold tracking-tight text-foreground">Event collections</h2>
+            <p className="text-sm text-muted-foreground">
+              Choose one of our signature experiences or let us tailor a celebration to your guest list.
+            </p>
           </div>
-
-          <div className="rounded-lg border border-neutral-200 bg-white p-4 shadow-sm">
-            <h3 className="font-semibold text-neutral-900 mb-2">Private Dining</h3>
-            <p className="text-sm text-neutral-600 mb-3">Exclusive room experience</p>
-            <ul className="space-y-1 text-xs text-neutral-600">
-              <li>• Up to 12 guests</li>
-              <li>• 5-course tasting menu</li>
-              <li>• Wine pairing</li>
-              <li>• 4-hour reservation</li>
-            </ul>
-          </div>
-
-          <div className="rounded-lg border border-neutral-200 bg-white p-4 shadow-sm">
-            <h3 className="font-semibold text-neutral-900 mb-2">Full Buyout</h3>
-            <p className="text-sm text-neutral-600 mb-3">Complete restaurant experience</p>
-            <ul className="space-y-1 text-xs text-neutral-600">
-              <li>• Up to 40 guests</li>
-              <li>• Custom menu design</li>
-              <li>• Full bar service</li>
-              <li>• Flexible duration</li>
-            </ul>
-          </div>
+          <Badge variant="subtle">Seasonal menus updated quarterly</Badge>
         </div>
-      </div>
-
-      <div className="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
-        <h2 className="text-xl font-semibold text-neutral-900 mb-4">Plan Your Event</h2>
-        <p className="text-sm text-neutral-600 mb-6">
-          Ready to create a memorable dining experience? Contact our events team to discuss your vision and receive a personalized proposal.
-        </p>
-        <div className="flex flex-col gap-4 sm:flex-row">
-          <a
-            href="/contact"
-            className="inline-flex items-center justify-center rounded-full bg-amber-600 px-6 py-3 text-sm font-semibold text-white shadow-sm hover:bg-amber-700"
-          >
-            Contact Events Team
-          </a>
-          <a
-            href="tel:+37255512345"
-            className="inline-flex items-center justify-center rounded-full border border-amber-600 px-6 py-3 text-sm font-semibold text-amber-600 hover:bg-amber-50"
-          >
-            Call +372 555 12345
-          </a>
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {eventPackages.map((pkg) => (
+            <Card key={pkg.title}>
+              <CardHeader className="space-y-2">
+                <CardTitle className="text-xl">{pkg.title}</CardTitle>
+                <CardDescription>{pkg.description}</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <ul className="space-y-2 text-sm text-muted-foreground">
+                  {pkg.features.map((feature) => (
+                    <li key={feature} className="flex items-start gap-2">
+                      <span className="mt-1 h-1.5 w-1.5 rounded-full bg-primary" aria-hidden />
+                      <span>{feature}</span>
+                    </li>
+                  ))}
+                </ul>
+              </CardContent>
+            </Card>
+          ))}
         </div>
-      </div>
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-[1.1fr,1fr]">
+        <Card className="h-full">
+          <CardHeader className="space-y-4">
+            <Badge variant="subtle">Plan together</Badge>
+            <CardTitle>Plan your event</CardTitle>
+            <CardDescription>
+              Tell us about your celebration and we&apos;ll curate a proposal covering menus, pairings, design, and timeline.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div className="flex flex-col gap-3 sm:flex-row">
+              <a href="/contact" className={cn(buttonClasses(), "flex-1 justify-center")}>
+                Contact events team
+              </a>
+              <a
+                href="tel:+37255512345"
+                className={cn(buttonClasses({ variant: "outline" }), "flex-1 justify-center")}
+              >
+                Call +372 555 12345
+              </a>
+            </div>
+            <p className="text-sm text-muted-foreground">
+              We&apos;ll schedule a design consultation, offer sample menus, and coordinate any site visits you may need.
+            </p>
+          </CardContent>
+        </Card>
+        <Card className="h-full">
+          <CardHeader className="space-y-4">
+            <Badge variant="outline">Enhancements</Badge>
+            <CardTitle>Moments your guests remember</CardTitle>
+            <CardDescription>
+              Signature touches that layer storytelling and surprise into your celebration.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4 text-sm text-muted-foreground">
+            <ul className="space-y-3">
+              <li className="flex items-start gap-2">
+                <span className="mt-1 h-1.5 w-1.5 rounded-full bg-primary" aria-hidden />
+                <span>Arrival ritual with smoke-infused cocktails and local botanicals</span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 h-1.5 w-1.5 rounded-full bg-primary" aria-hidden />
+                <span>Story-led menu cards illustrated by Estonian artists</span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 h-1.5 w-1.5 rounded-full bg-primary" aria-hidden />
+                <span>Late-night dessert and coffee atelier featuring house-made chocolates</span>
+              </li>
+            </ul>
+            <Separator />
+            <p>
+              Email
+              <a href="mailto:events@restorankiisi.ee" className="font-medium text-primary">
+                &nbsp;events@restorankiisi.ee
+              </a>
+              &nbsp;to explore custom entertainment, photography, and keepsake options.
+            </p>
+          </CardContent>
+        </Card>
+      </section>
     </div>
   );
 }

--- a/src/app/(marketing)/faq/page.tsx
+++ b/src/app/(marketing)/faq/page.tsx
@@ -1,150 +1,170 @@
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+const categories = [
+  {
+    title: "Reservations & dining",
+    badge: "Plan ahead",
+    questions: [
+      {
+        question: "Do I need a reservation?",
+        answer:
+          "Walk-ins are always welcome, but we recommend reserving for dinner and weekend services to guarantee your table.",
+      },
+      {
+        question: "How far in advance can I book?",
+        answer:
+          "Reservations open 30 days in advance. For celebrations or parties of 8 or more, we invite you to reach out earlier so we can plan together.",
+      },
+      {
+        question: "Do you accommodate dietary restrictions?",
+        answer:
+          "Absolutely. Let us know when booking or speak with your server—we can adapt menus for allergies, vegetarian, vegan, and gluten-free guests.",
+      },
+    ],
+  },
+  {
+    title: "Menu & ingredients",
+    badge: "Seasonal",
+    questions: [
+      {
+        question: "Is your menu seasonal?",
+        answer:
+          "Our menu shifts with the Baltic seasons. We collaborate with farmers and foragers, so dishes evolve as produce becomes available.",
+      },
+      {
+        question: "Do you offer vegetarian and vegan options?",
+        answer:
+          "Yes. Each menu features dedicated vegetarian dishes, and our chefs are happy to craft vegan courses with advance notice.",
+      },
+      {
+        question: "Can I view the menu before visiting?",
+        answer:
+          "Current menus are published online and refreshed weekly. We also share daily specials through our social media channels.",
+      },
+    ],
+  },
+  {
+    title: "Orders & takeaway",
+    badge: "To-go",
+    questions: [
+      {
+        question: "Do you offer takeaway or delivery?",
+        answer:
+          "Takeaway is available to collect from the restaurant. For business orders we can prepare invoices and organise scheduled pickups.",
+      },
+      {
+        question: "How do I place a takeaway order?",
+        answer:
+          "Order online through our website or give us a call. Most orders are ready within 20–30 minutes depending on service volume.",
+      },
+      {
+        question: "What payment methods do you accept?",
+        answer:
+          "We accept cash, major credit cards, and contactless payments. Invoices for corporate orders can be settled within 24 hours.",
+      },
+    ],
+  },
+  {
+    title: "Location & hours",
+    badge: "Visit",
+    questions: [
+      {
+        question: "Where are you located?",
+        answer:
+          "You&apos;ll find us in Tallinn Old Town with nearby parking and convenient public transport links. Our locations page includes maps and directions.",
+      },
+      {
+        question: "What are your opening hours?",
+        answer:
+          "Service hours vary seasonally. Check the locations page or call us for the latest schedule before you arrive.",
+      },
+    ],
+  },
+];
+
+function FAQItem({ question, answer }: { question: string; answer: string }) {
+  return (
+    <details className="group rounded-2xl border border-border/60 bg-muted/20 p-5 transition hover:border-border hover:bg-muted/40">
+      <summary className="flex cursor-pointer items-center justify-between gap-4 text-left [&::-webkit-details-marker]:hidden">
+        <span className="text-base font-semibold text-foreground">{question}</span>
+        <span className="text-sm font-medium text-primary transition group-open:rotate-45">+</span>
+      </summary>
+      <p className="mt-3 text-sm text-muted-foreground">{answer}</p>
+    </details>
+  );
+}
+
 export default function FAQPage() {
   return (
-    <div className="mx-auto max-w-4xl space-y-8 px-6 py-12">
-      <header className="space-y-2">
-        <h1 className="text-3xl font-semibold text-neutral-900">Frequently Asked Questions</h1>
-        <p className="text-sm text-neutral-500">
-          Find answers to common questions about dining at Restoran Kiisi.
-        </p>
-      </header>
-
-      <div className="space-y-6">
-        <div className="space-y-6">
-          <div className="space-y-4">
-            <h2 className="text-xl font-semibold text-neutral-900">Reservations & Dining</h2>
-            
-            <div className="space-y-4">
-              <div className="rounded-lg border border-neutral-200 bg-white p-4 shadow-sm">
-                <h3 className="font-semibold text-neutral-900 mb-2">Do I need a reservation?</h3>
-                <p className="text-sm text-neutral-600">
-                  While walk-ins are welcome, we highly recommend making a reservation, especially for dinner service 
-                  and weekend dining. You can make reservations online or by calling us directly.
-                </p>
-              </div>
-
-              <div className="rounded-lg border border-neutral-200 bg-white p-4 shadow-sm">
-                <h3 className="font-semibold text-neutral-900 mb-2">How far in advance can I make a reservation?</h3>
-                <p className="text-sm text-neutral-600">
-                  Reservations can be made up to 30 days in advance. For special occasions or large groups, 
-                  we recommend booking as early as possible.
-                </p>
-              </div>
-
-              <div className="rounded-lg border border-neutral-200 bg-white p-4 shadow-sm">
-                <h3 className="font-semibold text-neutral-900 mb-2">Do you accommodate dietary restrictions?</h3>
-                <p className="text-sm text-neutral-600">
-                  Yes, we're happy to accommodate dietary restrictions and allergies. Please inform us when 
-                  making your reservation or speak with your server about any specific needs.
-                </p>
-              </div>
-            </div>
-          </div>
-
-          <div className="space-y-4">
-            <h2 className="text-xl font-semibold text-neutral-900">Menu & Food</h2>
-            
-            <div className="space-y-4">
-              <div className="rounded-lg border border-neutral-200 bg-white p-4 shadow-sm">
-                <h3 className="font-semibold text-neutral-900 mb-2">Is your menu seasonal?</h3>
-                <p className="text-sm text-neutral-600">
-                  Yes, our menu changes seasonally to feature the freshest local ingredients. We work closely 
-                  with Estonian farmers and producers to bring you authentic, seasonal flavors.
-                </p>
-              </div>
-
-              <div className="rounded-lg border border-neutral-200 bg-white p-4 shadow-sm">
-                <h3 className="font-semibold text-neutral-900 mb-2">Do you offer vegetarian and vegan options?</h3>
-                <p className="text-sm text-neutral-600">
-                  Absolutely! We have several vegetarian and vegan dishes on our menu, and our chefs can 
-                  modify many other dishes to meet your dietary preferences.
-                </p>
-              </div>
-
-              <div className="rounded-lg border border-neutral-200 bg-white p-4 shadow-sm">
-                <h3 className="font-semibold text-neutral-900 mb-2">Can I see the menu before visiting?</h3>
-                <p className="text-sm text-neutral-600">
-                  Yes, you can view our current menu on our website. We also post daily specials on our 
-                  social media channels.
-                </p>
-              </div>
-            </div>
-          </div>
-
-          <div className="space-y-4">
-            <h2 className="text-xl font-semibold text-neutral-900">Orders & Takeaway</h2>
-            
-            <div className="space-y-4">
-              <div className="rounded-lg border border-neutral-200 bg-white p-4 shadow-sm">
-                <h3 className="font-semibold text-neutral-900 mb-2">Do you offer takeaway or delivery?</h3>
-                <p className="text-sm text-neutral-600">
-                  Yes, we offer takeaway orders that you can pick up at the restaurant. We also provide 
-                  invoice-by-email service for business orders.
-                </p>
-              </div>
-
-              <div className="rounded-lg border border-neutral-200 bg-white p-4 shadow-sm">
-                <h3 className="font-semibold text-neutral-900 mb-2">How do I place a takeaway order?</h3>
-                <p className="text-sm text-neutral-600">
-                  You can place takeaway orders through our website or by calling the restaurant directly. 
-                  Orders are typically ready within 20-30 minutes.
-                </p>
-              </div>
-
-              <div className="rounded-lg border border-neutral-200 bg-white p-4 shadow-sm">
-                <h3 className="font-semibold text-neutral-900 mb-2">What payment methods do you accept?</h3>
-                <p className="text-sm text-neutral-600">
-                  We accept cash, all major credit cards, and contactless payments. For takeaway orders, 
-                  you can pay on-site or request an invoice by email.
-                </p>
-              </div>
-            </div>
-          </div>
-
-          <div className="space-y-4">
-            <h2 className="text-xl font-semibold text-neutral-900">Location & Hours</h2>
-            
-            <div className="space-y-4">
-              <div className="rounded-lg border border-neutral-200 bg-white p-4 shadow-sm">
-                <h3 className="font-semibold text-neutral-900 mb-2">Where are you located?</h3>
-                <p className="text-sm text-neutral-600">
-                  We're located in the heart of Tallinn Old Town, easily accessible by public transport 
-                  and with nearby parking options. Check our locations page for detailed directions.
-                </p>
-              </div>
-
-              <div className="rounded-lg border border-neutral-200 bg-white p-4 shadow-sm">
-                <h3 className="font-semibold text-neutral-900 mb-2">What are your opening hours?</h3>
-                <p className="text-sm text-neutral-600">
-                  Our hours vary by day and season. Please check our locations page for current opening 
-                  hours, or call us directly for the most up-to-date information.
-                </p>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div className="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
-          <h2 className="text-xl font-semibold text-neutral-900 mb-4">Still Have Questions?</h2>
-          <p className="text-sm text-neutral-600 mb-6">
-            Can't find the answer you're looking for? Our team is here to help. Contact us directly 
-            and we'll be happy to assist you.
+    <div className="mx-auto max-w-5xl space-y-16 px-6 py-16">
+      <section className="space-y-6 text-center md:text-left">
+        <Badge className="mx-auto md:mx-0" variant="outline">
+          Frequently asked questions
+        </Badge>
+        <div className="space-y-3">
+          <h1 className="text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">Questions &amp; answers</h1>
+          <p className="text-base text-muted-foreground md:max-w-2xl">
+            Discover everything you need to know about dining with us—from reservations to takeaway and special requests.
           </p>
-          <div className="flex flex-col gap-4 sm:flex-row">
-            <a
-              href="/contact"
-              className="inline-flex items-center justify-center rounded-full bg-amber-600 px-6 py-3 text-sm font-semibold text-white shadow-sm hover:bg-amber-700"
-            >
-              Contact Us
-            </a>
-            <a
-              href="tel:+37255512345"
-              className="inline-flex items-center justify-center rounded-full border border-amber-600 px-6 py-3 text-sm font-semibold text-amber-600 hover:bg-amber-50"
-            >
-              Call +372 555 12345
-            </a>
-          </div>
         </div>
-      </div>
+      </section>
+
+      <section className="space-y-6">
+        {categories.map((category) => (
+          <Card key={category.title}>
+            <CardHeader className="space-y-4">
+              <div className="flex items-center justify-between gap-3">
+                <CardTitle>{category.title}</CardTitle>
+                <Badge variant="subtle">{category.badge}</Badge>
+              </div>
+              <CardDescription>
+                {category.title === "Reservations & dining"
+                  ? "Plan the perfect visit to our Old Town dining room."
+                  : category.title === "Menu & ingredients"
+                    ? "Explore how we source and craft every dish."
+                    : category.title === "Orders & takeaway"
+                      ? "Enjoy Kiisi at home or at the office."
+                      : "Know when to visit and how to find us."}
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {category.questions.map((question) => (
+                <FAQItem key={question.question} question={question.question} answer={question.answer} />
+              ))}
+            </CardContent>
+          </Card>
+        ))}
+      </section>
+
+      <section>
+        <Card className="text-center">
+          <CardHeader className="space-y-3">
+            <CardTitle className="text-2xl">Still curious?</CardTitle>
+            <CardDescription>
+              Can&apos;t find what you&apos;re looking for? Our guest relations team is happy to help plan your next visit.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm text-muted-foreground">
+            <p>
+              Email us at
+              <a href="mailto:hello@restorankiisi.ee" className="font-medium text-primary">
+                &nbsp;hello@restorankiisi.ee
+              </a>
+              &nbsp;or call +372 555 12345.
+            </p>
+            <p>
+              Prefer to chat in person? Stop by between 15:00 and 17:00 daily and we&apos;ll be ready with recommendations.
+            </p>
+          </CardContent>
+        </Card>
+      </section>
     </div>
   );
 }

--- a/src/app/(marketing)/gift-cards/page.tsx
+++ b/src/app/(marketing)/gift-cards/page.tsx
@@ -1,100 +1,224 @@
+import { Badge } from "@/components/ui/badge";
+import { buttonClasses } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { cn } from "@/lib/utils";
+
+const giftTypes = [
+  {
+    title: "Physical Gift Cards",
+    badge: "Keepsake",
+    description:
+      "Beautifully printed cards presented in a linen-textured sleeve, ideal for gifting in person.",
+    highlights: [
+      "Available in €25, €50, €100, and €200 denominations",
+      "Hand-wrapped presentation with wax seal",
+      "Can be personalised with a handwritten note",
+      "Redeemable at all Restoran Kiisi locations",
+    ],
+  },
+  {
+    title: "Digital Gift Cards",
+    badge: "Instant",
+    description:
+      "Delivered instantly by email with the option to schedule for a special date—perfect for last-minute surprises.",
+    highlights: [
+      "Custom amount options from €10 to €500",
+      "Add a personalised message and photograph",
+      "Secure online redemption",
+      "Downloadable PDF for printing at home",
+    ],
+  },
+];
+
+const giftTiers = [
+  {
+    value: "€25",
+    description: "An introduction to our seasonal lunch menu",
+  },
+  {
+    value: "€50",
+    description: "A three-course dinner for one or shared appetisers",
+  },
+  {
+    value: "€100",
+    description: "A tasting experience for two guests",
+  },
+  {
+    value: "€200",
+    description: "An immersive celebration with curated wine pairing",
+  },
+];
+
+const etiquette = [
+  "Gift cards never expire and can be redeemed in multiple visits",
+  "Balance enquiries are available in person or via email",
+  "Non-transferable for cash or credit with lost cards unable to be replaced",
+  "Applicable to dining, takeaway, and event experiences",
+  "Change is offered on purchases below the remaining card value",
+];
+
 export default function GiftCardsPage() {
   return (
-    <div className="mx-auto max-w-4xl space-y-8 px-6 py-12">
-      <header className="space-y-2">
-        <h1 className="text-3xl font-semibold text-neutral-900">Gift Cards</h1>
-        <p className="text-sm text-neutral-500">
-          Share the experience of Restoran Kiisi with someone special. Perfect for any occasion.
-        </p>
-      </header>
-
-      <div className="grid gap-8 md:grid-cols-2">
-        <div className="space-y-4">
-          <h2 className="text-xl font-semibold text-neutral-900">Physical Gift Cards</h2>
-          <p className="text-sm text-neutral-600">
-            Beautifully designed gift cards available for purchase at any of our locations. 
-            Each card comes in an elegant presentation box, perfect for gifting.
+    <div className="mx-auto max-w-5xl space-y-16 px-6 py-16">
+      <section className="space-y-6 text-center md:text-left">
+        <Badge className="mx-auto md:mx-0" variant="outline">
+          Share the Kiisi table
+        </Badge>
+        <div className="space-y-3">
+          <h1 className="text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">
+            Gift Cards
+          </h1>
+          <p className="text-base text-muted-foreground md:max-w-2xl">
+            Treat the people you love to a night in Tallinn&apos;s Old Town. Our gift cards unlock
+            chef-driven seasonal menus, intimate events, and cellar pairings crafted by the Kiisi team.
           </p>
-          <ul className="space-y-2 text-sm text-neutral-600">
-            <li>• Available in €25, €50, €100, and €200 denominations</li>
-            <li>• Elegant presentation packaging</li>
-            <li>• No expiration date</li>
-            <li>• Valid at all Restoran Kiisi locations</li>
-          </ul>
         </div>
-
-        <div className="space-y-4">
-          <h2 className="text-xl font-semibold text-neutral-900">Digital Gift Cards</h2>
-          <p className="text-sm text-neutral-600">
-            Instant digital gift cards delivered via email. Perfect for last-minute gifts 
-            or when you can't visit us in person.
-          </p>
-          <ul className="space-y-2 text-sm text-neutral-600">
-            <li>• Instant email delivery</li>
-            <li>• Custom amount options (€10-€500)</li>
-            <li>• Personalized message included</li>
-            <li>• Easy online redemption</li>
-          </ul>
+        <div className="flex flex-col items-center gap-3 text-sm text-muted-foreground md:flex-row md:items-center">
+          <span className="font-medium text-foreground">Need something today?</span>
+          <span className="rounded-full bg-muted px-4 py-1">Digital delivery arrives in moments.</span>
         </div>
-      </div>
+      </section>
 
-      <div className="space-y-6">
-        <h2 className="text-xl font-semibold text-neutral-900">Gift Card Options</h2>
-        <div className="grid gap-6 md:grid-cols-4">
-          <div className="rounded-lg border border-neutral-200 bg-white p-4 shadow-sm text-center">
-            <div className="text-2xl font-bold text-amber-600 mb-2">€25</div>
-            <p className="text-sm text-neutral-600">Perfect for a casual lunch or coffee break</p>
-          </div>
+      <section className="grid gap-6 md:grid-cols-2">
+        {giftTypes.map((type) => (
+          <Card key={type.title} className="h-full">
+            <CardHeader className="space-y-4">
+              <Badge>{type.badge}</Badge>
+              <CardTitle>{type.title}</CardTitle>
+              <CardDescription>{type.description}</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ul className="space-y-3 text-sm text-muted-foreground">
+                {type.highlights.map((highlight) => (
+                  <li key={highlight} className="flex items-start gap-2">
+                    <span className="mt-1 h-1.5 w-1.5 rounded-full bg-primary" aria-hidden />
+                    <span>{highlight}</span>
+                  </li>
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
+        ))}
+      </section>
 
-          <div className="rounded-lg border border-neutral-200 bg-white p-4 shadow-sm text-center">
-            <div className="text-2xl font-bold text-amber-600 mb-2">€50</div>
-            <p className="text-sm text-neutral-600">Great for a dinner for two</p>
+      <section className="space-y-6">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h2 className="text-2xl font-semibold tracking-tight text-foreground">Signature tiers</h2>
+            <p className="text-sm text-muted-foreground">
+              Choose a denomination to match the experience you&apos;d like to gift.
+            </p>
           </div>
-
-          <div className="rounded-lg border border-neutral-200 bg-white p-4 shadow-sm text-center">
-            <div className="text-2xl font-bold text-amber-600 mb-2">€100</div>
-            <p className="text-sm text-neutral-600">Ideal for a special celebration</p>
-          </div>
-
-          <div className="rounded-lg border border-neutral-200 bg-white p-4 shadow-sm text-center">
-            <div className="text-2xl font-bold text-amber-600 mb-2">€200</div>
-            <p className="text-sm text-neutral-600">Perfect for multiple visits or large groups</p>
-          </div>
+          <Badge variant="subtle">Flexible amounts available</Badge>
         </div>
-      </div>
-
-      <div className="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
-        <h2 className="text-xl font-semibold text-neutral-900 mb-4">Purchase Gift Cards</h2>
-        <p className="text-sm text-neutral-600 mb-6">
-          Visit any of our locations to purchase physical gift cards, or contact us to arrange 
-          digital gift card delivery.
-        </p>
-        <div className="flex flex-col gap-4 sm:flex-row">
-          <a
-            href="/locations"
-            className="inline-flex items-center justify-center rounded-full bg-amber-600 px-6 py-3 text-sm font-semibold text-white shadow-sm hover:bg-amber-700"
-          >
-            Find Locations
-          </a>
-          <a
-            href="/contact"
-            className="inline-flex items-center justify-center rounded-full border border-amber-600 px-6 py-3 text-sm font-semibold text-amber-600 hover:bg-amber-50"
-          >
-            Contact for Digital Cards
-          </a>
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {giftTiers.map((tier) => (
+            <Card key={tier.value} className="text-center">
+              <CardHeader className="space-y-3">
+                <CardTitle className="text-3xl font-semibold text-primary">{tier.value}</CardTitle>
+                <CardDescription>{tier.description}</CardDescription>
+              </CardHeader>
+            </Card>
+          ))}
         </div>
-      </div>
+      </section>
 
-      <div className="rounded-lg border border-amber-200 bg-amber-50 p-4">
-        <h3 className="font-semibold text-amber-800 mb-2">Terms & Conditions</h3>
-        <ul className="space-y-1 text-sm text-amber-700">
-          <li>• Gift cards have no expiration date</li>
-          <li>• Cannot be exchanged for cash</li>
-          <li>• Valid at all Restoran Kiisi locations</li>
-          <li>• Lost or stolen cards cannot be replaced</li>
-          <li>• Change will be provided for purchases under the card value</li>
-        </ul>
-      </div>
+      <section className="grid gap-6 lg:grid-cols-[1.2fr,1fr]">
+        <Card className="h-full">
+          <CardHeader className="space-y-4">
+            <Badge variant="subtle">How to purchase</Badge>
+            <CardTitle>Purchase gift cards</CardTitle>
+            <CardDescription>
+              Visit us in person for a beautifully presented card or request a digital delivery by email.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div className="flex flex-col gap-3 sm:flex-row">
+              <a
+                href="/locations"
+                className={cn(buttonClasses(), "flex-1 justify-center")}
+              >
+                Find locations
+              </a>
+              <a
+                href="/contact"
+                className={cn(buttonClasses({ variant: "outline" }), "flex-1 justify-center")}
+              >
+                Arrange digital delivery
+              </a>
+            </div>
+            <p className="text-sm text-muted-foreground">
+              Prefer a bespoke experience? Our guest relations team can curate progressive tasting journeys, wine pairings,
+              and add-on experiences tailored to your recipient.
+            </p>
+          </CardContent>
+        </Card>
+        <Card className="h-full">
+          <CardHeader className="space-y-4">
+            <Badge variant="outline">Etiquette</Badge>
+            <CardTitle>Terms &amp; details</CardTitle>
+            <CardDescription>
+              A few notes to ensure your recipient enjoys every moment of their Kiisi experience.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ul className="space-y-3 text-sm text-muted-foreground">
+              {etiquette.map((item) => (
+                <li key={item} className="flex items-start gap-2">
+                  <span className="mt-1 h-1.5 w-1.5 rounded-full bg-primary" aria-hidden />
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+          <CardFooter className="justify-start bg-transparent px-8 py-6">
+            <a href="/terms" className="text-sm font-semibold text-primary transition hover:text-primary/80">
+              Read full terms of service
+            </a>
+          </CardFooter>
+        </Card>
+      </section>
+
+      <section>
+        <Card className="overflow-hidden">
+          <CardHeader className="space-y-3">
+            <CardTitle className="text-2xl">Corporate &amp; group gifting</CardTitle>
+            <CardDescription>
+              Need to send multiple gifts? We can coordinate tailored deliveries, handwritten notes, and invoicing for teams or
+              clients.
+            </CardDescription>
+          </CardHeader>
+          <Separator />
+          <CardContent className="space-y-4">
+            <p className="text-sm text-muted-foreground">
+              Email <a href="mailto:events@restorankiisi.ee" className="font-medium text-primary">events@restorankiisi.ee</a>
+              &nbsp;with your preferred quantities and personalised touches, and our concierge will respond within one business day.
+            </p>
+            <div className="flex flex-col gap-3 sm:flex-row">
+              <a
+                href="mailto:events@restorankiisi.ee"
+                className={cn(buttonClasses(), "flex-1 justify-center")}
+              >
+                Contact concierge
+              </a>
+              <a
+                href="/events"
+                className={cn(buttonClasses({ variant: "outline" }), "flex-1 justify-center")}
+              >
+                Explore private events
+              </a>
+            </div>
+          </CardContent>
+        </Card>
+      </section>
     </div>
   );
 }

--- a/src/app/(marketing)/privacy/page.tsx
+++ b/src/app/(marketing)/privacy/page.tsx
@@ -1,119 +1,167 @@
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+const sections = [
+  {
+    title: "Information we collect",
+    description:
+      "We gather details you share with us directly as well as information that helps us keep the website secure and easy to use.",
+    subsections: [
+      {
+        subtitle: "Personal information",
+        items: [
+          "Name and contact information (email, phone number)",
+          "Reservation, order history, and guest preferences",
+          "Dietary notes and special requests",
+          "Payment details processed securely via third parties",
+        ],
+      },
+      {
+        subtitle: "Automatically collected information",
+        items: [
+          "Website usage data and analytics",
+          "Device details such as browser, operating system, and language",
+          "IP address and general location",
+          "Cookies and similar tracking technologies",
+        ],
+      },
+    ],
+  },
+  {
+    title: "How we use your information",
+    description: "Your information allows us to deliver a refined dining experience and keep you informed about Kiisi.",
+    items: [
+      "Process reservations, orders, and event enquiries",
+      "Communicate about your dining experience and service updates",
+      "Share menu news and seasonal offers when you opt in",
+      "Improve our website, menus, and hospitality through feedback",
+      "Comply with legal obligations and maintain security",
+    ],
+  },
+  {
+    title: "Information sharing",
+    description:
+      "We respect your privacy—your personal details are only shared in limited circumstances when necessary to operate our services.",
+    items: [
+      "With your explicit consent",
+      "With trusted service providers supporting reservations, payments, and communications",
+      "When required by law or to protect the rights and safety of our guests and team",
+      "In the event of a business transfer or acquisition",
+    ],
+  },
+  {
+    title: "Data security",
+    description:
+      "We implement administrative, technical, and physical safeguards to protect your personal information. While no internet transmission is entirely risk-free, we continually review our practices to keep your data safe.",
+  },
+  {
+    title: "Your rights",
+    description:
+      "Depending on your location, you may have certain rights regarding the personal information we hold about you.",
+    items: [
+      "Access and review the information we store",
+      "Request corrections to inaccurate details",
+      "Ask for deletion where permitted by law",
+      "Object to or restrict certain processing activities",
+      "Withdraw consent for marketing communications at any time",
+    ],
+  },
+  {
+    title: "Cookies and tracking",
+    description:
+      "We use cookies to improve performance, analyse traffic, and personalise content. You can adjust your browser settings to manage or disable cookies, though this may impact some site features.",
+  },
+  {
+    title: "Changes to this policy",
+    description:
+      "We may update this policy periodically. When we make material changes, we&apos;ll update the date above and, when appropriate, notify you directly.",
+  },
+];
+
+const contactDetails = [
+  { label: "Email", value: "privacy@restorankiisi.ee" },
+  { label: "Phone", value: "+372 555 12345" },
+  { label: "Address", value: "Tallinn Old Town, Estonia" },
+];
+
 export default function PrivacyPage() {
   return (
-    <div className="mx-auto max-w-4xl space-y-8 px-6 py-12">
-      <header className="space-y-2">
-        <h1 className="text-3xl font-semibold text-neutral-900">Privacy Policy</h1>
-        <p className="text-sm text-neutral-500">
-          Last updated: October 6, 2025
-        </p>
-      </header>
-
-      <div className="space-y-8">
-        <div className="space-y-4">
-          <h2 className="text-xl font-semibold text-neutral-900">Information We Collect</h2>
-          <p className="text-sm text-neutral-600">
-            At Restoran Kiisi, we collect information you provide directly to us, such as when you make a reservation, 
-            place an order, create an account, or contact us for support.
-          </p>
-          
-          <div className="space-y-3">
-            <h3 className="text-lg font-semibold text-neutral-900">Personal Information</h3>
-            <ul className="space-y-2 text-sm text-neutral-600 ml-4">
-              <li>• Name and contact information (email, phone number)</li>
-              <li>• Reservation and order history</li>
-              <li>• Dietary preferences and special requests</li>
-              <li>• Payment information (processed securely through third-party providers)</li>
-            </ul>
-          </div>
-
-          <div className="space-y-3">
-            <h3 className="text-lg font-semibold text-neutral-900">Automatically Collected Information</h3>
-            <ul className="space-y-2 text-sm text-neutral-600 ml-4">
-              <li>• Website usage data and analytics</li>
-              <li>• Device information and browser type</li>
-              <li>• IP address and location data</li>
-              <li>• Cookies and similar tracking technologies</li>
-            </ul>
-          </div>
-        </div>
-
-        <div className="space-y-4">
-          <h2 className="text-xl font-semibold text-neutral-900">How We Use Your Information</h2>
-          <p className="text-sm text-neutral-600">
-            We use the information we collect to provide, maintain, and improve our services:
-          </p>
-          <ul className="space-y-2 text-sm text-neutral-600 ml-4">
-            <li>• Process reservations and orders</li>
-            <li>• Communicate with you about your dining experience</li>
-            <li>• Send you updates about our menu and special offers (with your consent)</li>
-            <li>• Improve our website and services</li>
-            <li>• Comply with legal obligations</li>
-          </ul>
-        </div>
-
-        <div className="space-y-4">
-          <h2 className="text-xl font-semibold text-neutral-900">Information Sharing</h2>
-          <p className="text-sm text-neutral-600">
-            We do not sell, trade, or otherwise transfer your personal information to third parties, except in the following circumstances:
-          </p>
-          <ul className="space-y-2 text-sm text-neutral-600 ml-4">
-            <li>• With your explicit consent</li>
-            <li>• To trusted service providers who assist in operating our website and conducting our business</li>
-            <li>• When required by law or to protect our rights and safety</li>
-            <li>• In connection with a business transfer or acquisition</li>
-          </ul>
-        </div>
-
-        <div className="space-y-4">
-          <h2 className="text-xl font-semibold text-neutral-900">Data Security</h2>
-          <p className="text-sm text-neutral-600">
-            We implement appropriate security measures to protect your personal information against unauthorized access, 
-            alteration, disclosure, or destruction. However, no method of transmission over the internet is 100% secure.
+    <div className="mx-auto max-w-5xl space-y-16 px-6 py-16">
+      <section className="space-y-6 text-center md:text-left">
+        <Badge className="mx-auto md:mx-0" variant="outline">
+          Privacy policy
+        </Badge>
+        <div className="space-y-3">
+          <h1 className="text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">Your privacy matters</h1>
+          <p className="text-base text-muted-foreground md:max-w-2xl">
+            Last updated: <strong>October 6, 2025</strong>. We are committed to protecting your personal information and being transparent about how it&apos;s used.
           </p>
         </div>
+      </section>
 
-        <div className="space-y-4">
-          <h2 className="text-xl font-semibold text-neutral-900">Your Rights</h2>
-          <p className="text-sm text-neutral-600">
-            Under applicable data protection laws, you have the right to:
-          </p>
-          <ul className="space-y-2 text-sm text-neutral-600 ml-4">
-            <li>• Access and review your personal information</li>
-            <li>• Correct inaccurate or incomplete information</li>
-            <li>• Request deletion of your personal information</li>
-            <li>• Object to or restrict processing of your information</li>
-            <li>• Withdraw consent for marketing communications</li>
-          </ul>
-        </div>
+      <section className="space-y-6">
+        {sections.map((section) => (
+          <Card key={section.title}>
+            <CardHeader className="space-y-3">
+              <CardTitle>{section.title}</CardTitle>
+              <CardDescription>{section.description}</CardDescription>
+            </CardHeader>
+            {section.subsections ? (
+              <CardContent className="space-y-6 text-sm text-muted-foreground">
+                {section.subsections.map((subsection) => (
+                  <div key={subsection.subtitle} className="space-y-3">
+                    <p className="text-sm font-semibold text-foreground">{subsection.subtitle}</p>
+                    <ul className="space-y-2">
+                      {subsection.items.map((item) => (
+                        <li key={item} className="flex items-start gap-2">
+                          <span className="mt-1 h-1.5 w-1.5 rounded-full bg-primary" aria-hidden />
+                          <span>{item}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </CardContent>
+            ) : section.items ? (
+              <CardContent className="space-y-3 text-sm text-muted-foreground">
+                <ul className="space-y-2">
+                  {section.items.map((item) => (
+                    <li key={item} className="flex items-start gap-2">
+                      <span className="mt-1 h-1.5 w-1.5 rounded-full bg-primary" aria-hidden />
+                      <span>{item}</span>
+                    </li>
+                  ))}
+                </ul>
+              </CardContent>
+            ) : null}
+          </Card>
+        ))}
+      </section>
 
-        <div className="space-y-4">
-          <h2 className="text-xl font-semibold text-neutral-900">Cookies and Tracking</h2>
-          <p className="text-sm text-neutral-600">
-            We use cookies and similar technologies to enhance your browsing experience, analyze website traffic, 
-            and personalize content. You can control cookie settings through your browser preferences.
-          </p>
-        </div>
-
-        <div className="space-y-4">
-          <h2 className="text-xl font-semibold text-neutral-900">Contact Us</h2>
-          <p className="text-sm text-neutral-600">
-            If you have any questions about this Privacy Policy or our data practices, please contact us:
-          </p>
-          <div className="space-y-2 text-sm text-neutral-600">
-            <p><strong>Email:</strong> privacy@restorankiisi.ee</p>
-            <p><strong>Phone:</strong> +372 555 12345</p>
-            <p><strong>Address:</strong> Tallinn Old Town, Estonia</p>
-          </div>
-        </div>
-
-        <div className="space-y-4">
-          <h2 className="text-xl font-semibold text-neutral-900">Changes to This Policy</h2>
-          <p className="text-sm text-neutral-600">
-            We may update this Privacy Policy from time to time. We will notify you of any material changes by 
-            posting the new policy on this page and updating the "Last updated" date.
-          </p>
-        </div>
-      </div>
+      <section>
+        <Card>
+          <CardHeader className="space-y-3">
+            <CardTitle>Contact us</CardTitle>
+            <CardDescription>
+              Have questions about this policy or how we handle your information? We&apos;re here to help.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-4 text-sm text-muted-foreground sm:grid-cols-3">
+            {contactDetails.map((detail) => (
+              <div key={detail.label} className="rounded-2xl border border-border/60 bg-muted/20 p-4">
+                <p className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">{detail.label}</p>
+                <p className="mt-2 text-sm font-medium text-foreground">{detail.value}</p>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      </section>
     </div>
   );
 }

--- a/src/app/(marketing)/terms/page.tsx
+++ b/src/app/(marketing)/terms/page.tsx
@@ -1,144 +1,187 @@
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+const sections = [
+  {
+    title: "Acceptance of terms",
+    description:
+      "By accessing or using the Restoran Kiisi website, reservations platform, or services, you agree to these Terms of Service. If you do not agree, please refrain from using our services.",
+  },
+  {
+    title: "Reservations and bookings",
+    subsections: [
+      {
+        subtitle: "Reservation policy",
+        items: [
+          "Reservations are subject to availability and restaurant capacity",
+          "We hold tables for 15 minutes past the reserved time",
+          "Large party bookings may require a deposit or credit card guarantee",
+          "Cancellations should be made at least 24 hours in advance",
+        ],
+      },
+      {
+        subtitle: "Modifications and cancellations",
+        items: [
+          "Adjustments must be made via our website or by calling the restaurant",
+          "No-shows may incur a cancellation fee for larger groups",
+          "We reserve the right to modify or cancel reservations due to unforeseen circumstances",
+        ],
+      },
+    ],
+  },
+  {
+    title: "Orders and payment",
+    subsections: [
+      {
+        subtitle: "Order terms",
+        items: [
+          "All prices are subject to change without notice",
+          "Menu items and availability may vary",
+          "Orders are prepared in the sequence they are received",
+          "Ready times are estimates and may shift based on kitchen volume",
+        ],
+      },
+      {
+        subtitle: "Payment policy",
+        items: [
+          "Payment is due at the time of service unless otherwise agreed",
+          "We accept cash, major credit cards, and contactless payments",
+          "Invoice-by-email orders must be settled within 24 hours",
+          "All prices include applicable taxes",
+        ],
+      },
+    ],
+  },
+  {
+    title: "Gift cards",
+    items: [
+      "Gift cards do not expire and may be redeemed across all Restoran Kiisi locations",
+      "Cards cannot be exchanged for cash or replaced if lost or stolen",
+      "Change is provided for purchases below the remaining balance",
+      "Additional terms may apply to promotional or corporate gift card programmes",
+    ],
+  },
+  {
+    title: "User conduct",
+    description: "Guests agree not to misuse the website or services. This includes refraining from activities that:",
+    items: [
+      "Violate any applicable laws or regulations",
+      "Transmit harmful, offensive, or inappropriate content",
+      "Interfere with the operation or security of our website and systems",
+      "Attempt to gain unauthorised access to our infrastructure",
+    ],
+  },
+  {
+    title: "Limitation of liability",
+    description:
+      "Restoran Kiisi is not liable for indirect, incidental, special, consequential, or punitive damages arising from your access to or use of our services, to the extent permitted by law.",
+  },
+  {
+    title: "Intellectual property",
+    description:
+      "All content on this site—including text, graphics, logos, imagery, and software—is the property of Restoran Kiisi and protected by copyright and other intellectual property laws.",
+  },
+  {
+    title: "Privacy",
+    description:
+      "Your privacy is important to us. Our Privacy Policy explains how we collect, use, and safeguard personal information. By using our services you also agree to the terms outlined there.",
+  },
+  {
+    title: "Governing law",
+    description:
+      "These terms are governed by and construed in accordance with the laws of Estonia, without regard to conflicts of law principles.",
+  },
+  {
+    title: "Changes to terms",
+    description:
+      "We may update these terms from time to time. Changes take effect immediately upon posting. Continued use of our services constitutes acceptance of the revised terms.",
+  },
+];
+
+const contactDetails = [
+  { label: "Email", value: "legal@restorankiisi.ee" },
+  { label: "Phone", value: "+372 555 12345" },
+  { label: "Address", value: "Tallinn Old Town, Estonia" },
+];
+
 export default function TermsPage() {
   return (
-    <div className="mx-auto max-w-4xl space-y-8 px-6 py-12">
-      <header className="space-y-2">
-        <h1 className="text-3xl font-semibold text-neutral-900">Terms of Service</h1>
-        <p className="text-sm text-neutral-500">
-          Last updated: October 6, 2025
-        </p>
-      </header>
-
-      <div className="space-y-8">
-        <div className="space-y-4">
-          <h2 className="text-xl font-semibold text-neutral-900">Acceptance of Terms</h2>
-          <p className="text-sm text-neutral-600">
-            By accessing and using the Restoran Kiisi website and services, you accept and agree to be bound by the 
-            terms and provision of this agreement. If you do not agree to abide by the above, please do not use this service.
+    <div className="mx-auto max-w-5xl space-y-16 px-6 py-16">
+      <section className="space-y-6 text-center md:text-left">
+        <Badge className="mx-auto md:mx-0" variant="outline">
+          Terms of service
+        </Badge>
+        <div className="space-y-3">
+          <h1 className="text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">Our guest agreement</h1>
+          <p className="text-base text-muted-foreground md:max-w-2xl">
+            Last updated: <strong>October 6, 2025</strong>. These terms keep every experience with Restoran Kiisi respectful, safe, and memorable.
           </p>
         </div>
+      </section>
 
-        <div className="space-y-4">
-          <h2 className="text-xl font-semibold text-neutral-900">Reservations and Bookings</h2>
-          <div className="space-y-3">
-            <h3 className="text-lg font-semibold text-neutral-900">Reservation Policy</h3>
-            <ul className="space-y-2 text-sm text-neutral-600 ml-4">
-              <li>• Reservations are subject to availability and restaurant capacity</li>
-              <li>• We hold reservations for 15 minutes past the reserved time</li>
-              <li>• Large party reservations may require a deposit or credit card guarantee</li>
-              <li>• Cancellations should be made at least 24 hours in advance</li>
-            </ul>
-          </div>
+      <section className="space-y-6">
+        {sections.map((section) => (
+          <Card key={section.title}>
+            <CardHeader className="space-y-3">
+              <CardTitle>{section.title}</CardTitle>
+              {section.description ? <CardDescription>{section.description}</CardDescription> : null}
+            </CardHeader>
+            {section.subsections ? (
+              <CardContent className="space-y-6 text-sm text-muted-foreground">
+                {section.subsections.map((subsection) => (
+                  <div key={subsection.subtitle} className="space-y-3">
+                    <p className="text-sm font-semibold text-foreground">{subsection.subtitle}</p>
+                    <ul className="space-y-2">
+                      {subsection.items.map((item) => (
+                        <li key={item} className="flex items-start gap-2">
+                          <span className="mt-1 h-1.5 w-1.5 rounded-full bg-primary" aria-hidden />
+                          <span>{item}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </CardContent>
+            ) : section.items ? (
+              <CardContent className="space-y-3 text-sm text-muted-foreground">
+                <ul className="space-y-2">
+                  {section.items.map((item) => (
+                    <li key={item} className="flex items-start gap-2">
+                      <span className="mt-1 h-1.5 w-1.5 rounded-full bg-primary" aria-hidden />
+                      <span>{item}</span>
+                    </li>
+                  ))}
+                </ul>
+              </CardContent>
+            ) : null}
+          </Card>
+        ))}
+      </section>
 
-          <div className="space-y-3">
-            <h3 className="text-lg font-semibold text-neutral-900">Modifications and Cancellations</h3>
-            <ul className="space-y-2 text-sm text-neutral-600 ml-4">
-              <li>• Changes to reservations must be made through our website or by phone</li>
-              <li>• No-shows may be subject to cancellation fees for large parties</li>
-              <li>• We reserve the right to modify or cancel reservations due to unforeseen circumstances</li>
-            </ul>
-          </div>
-        </div>
-
-        <div className="space-y-4">
-          <h2 className="text-xl font-semibold text-neutral-900">Orders and Payment</h2>
-          <div className="space-y-3">
-            <h3 className="text-lg font-semibold text-neutral-900">Order Terms</h3>
-            <ul className="space-y-2 text-sm text-neutral-600 ml-4">
-              <li>• All prices are subject to change without notice</li>
-              <li>• Menu items and availability may vary</li>
-              <li>• Orders are processed in the order they are received</li>
-              <li>• Estimated ready times are approximate and may vary</li>
-            </ul>
-          </div>
-
-          <div className="space-y-3">
-            <h3 className="text-lg font-semibold text-neutral-900">Payment Policy</h3>
-            <ul className="space-y-2 text-sm text-neutral-600 ml-4">
-              <li>• Payment is due at the time of service unless otherwise arranged</li>
-              <li>• We accept cash, credit cards, and contactless payments</li>
-              <li>• Invoice-by-email orders must be settled within 24 hours</li>
-              <li>• All prices include applicable taxes</li>
-            </ul>
-          </div>
-        </div>
-
-        <div className="space-y-4">
-          <h2 className="text-xl font-semibold text-neutral-900">Gift Cards</h2>
-          <ul className="space-y-2 text-sm text-neutral-600 ml-4">
-            <li>• Gift cards have no expiration date</li>
-            <li>• Gift cards cannot be exchanged for cash</li>
-            <li>• Lost or stolen gift cards cannot be replaced</li>
-            <li>• Gift cards are valid at all Restoran Kiisi locations</li>
-            <li>• Change will be provided for purchases under the card value</li>
-          </ul>
-        </div>
-
-        <div className="space-y-4">
-          <h2 className="text-xl font-semibold text-neutral-900">User Conduct</h2>
-          <p className="text-sm text-neutral-600">
-            Users agree not to use the service to:
-          </p>
-          <ul className="space-y-2 text-sm text-neutral-600 ml-4">
-            <li>• Violate any applicable laws or regulations</li>
-            <li>• Transmit harmful, offensive, or inappropriate content</li>
-            <li>• Interfere with the operation of our website or services</li>
-            <li>• Attempt to gain unauthorized access to our systems</li>
-          </ul>
-        </div>
-
-        <div className="space-y-4">
-          <h2 className="text-xl font-semibold text-neutral-900">Limitation of Liability</h2>
-          <p className="text-sm text-neutral-600">
-            Restoran Kiisi shall not be liable for any indirect, incidental, special, consequential, or punitive damages, 
-            including but not limited to loss of profits, data, or use, incurred by you or any third party, whether in 
-            an action in contract or tort, arising from your access to or use of our services.
-          </p>
-        </div>
-
-        <div className="space-y-4">
-          <h2 className="text-xl font-semibold text-neutral-900">Intellectual Property</h2>
-          <p className="text-sm text-neutral-600">
-            All content on this website, including text, graphics, logos, images, and software, is the property of 
-            Restoran Kiisi and is protected by copyright and other intellectual property laws.
-          </p>
-        </div>
-
-        <div className="space-y-4">
-          <h2 className="text-xl font-semibold text-neutral-900">Privacy</h2>
-          <p className="text-sm text-neutral-600">
-            Your privacy is important to us. Please review our Privacy Policy, which also governs your use of our services, 
-            to understand our practices.
-          </p>
-        </div>
-
-        <div className="space-y-4">
-          <h2 className="text-xl font-semibold text-neutral-900">Governing Law</h2>
-          <p className="text-sm text-neutral-600">
-            These terms shall be governed by and construed in accordance with the laws of Estonia, without regard to 
-            its conflict of law provisions.
-          </p>
-        </div>
-
-        <div className="space-y-4">
-          <h2 className="text-xl font-semibold text-neutral-900">Changes to Terms</h2>
-          <p className="text-sm text-neutral-600">
-            We reserve the right to modify these terms at any time. Changes will be effective immediately upon posting 
-            on this page. Your continued use of our services after any changes constitutes acceptance of the new terms.
-          </p>
-        </div>
-
-        <div className="space-y-4">
-          <h2 className="text-xl font-semibold text-neutral-900">Contact Information</h2>
-          <p className="text-sm text-neutral-600">
-            If you have any questions about these Terms of Service, please contact us:
-          </p>
-          <div className="space-y-2 text-sm text-neutral-600">
-            <p><strong>Email:</strong> legal@restorankiisi.ee</p>
-            <p><strong>Phone:</strong> +372 555 12345</p>
-            <p><strong>Address:</strong> Tallinn Old Town, Estonia</p>
-          </div>
-        </div>
-      </div>
+      <section>
+        <Card>
+          <CardHeader className="space-y-3">
+            <CardTitle>Contact us</CardTitle>
+            <CardDescription>
+              Questions about these terms? Reach out and our management team will respond promptly.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-4 text-sm text-muted-foreground sm:grid-cols-3">
+            {contactDetails.map((detail) => (
+              <div key={detail.label} className="rounded-2xl border border-border/60 bg-muted/20 p-4">
+                <p className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">{detail.label}</p>
+                <p className="mt-2 text-sm font-medium text-foreground">{detail.value}</p>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      </section>
     </div>
   );
 }

--- a/src/components/navigation/navigation-bar.tsx
+++ b/src/components/navigation/navigation-bar.tsx
@@ -2,9 +2,11 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
 
 import { Badge } from "@/components/ui/badge";
-import { buttonClasses } from "@/components/ui/button";
+import { Button, buttonClasses } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
 import { cn } from "@/lib/utils";
 
 export type NavigationLink = {
@@ -40,16 +42,24 @@ function isActivePath(pathname: string, href: string) {
 
 export function NavigationBar({ primary, secondary, mobile }: NavigationBarProps) {
   const pathname = usePathname();
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  useEffect(() => {
+    setMobileOpen(false);
+  }, [pathname]);
 
   return (
-    <header className="sticky top-0 z-50 border-b border-border/80 bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-      <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-primary/40 to-transparent" aria-hidden />
-      <div className="mx-auto flex max-w-6xl items-center justify-between gap-6 px-6 py-4">
+    <header className="sticky top-0 z-50 border-b border-border/60 bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+      <div
+        className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-primary/50 to-transparent"
+        aria-hidden
+      />
+      <div className="relative mx-auto flex h-20 w-full max-w-6xl items-center justify-between gap-4 px-6">
         <Link
           href="/"
-          className="group inline-flex items-center gap-3 rounded-full border border-transparent px-3 py-1 transition hover:border-border/80"
+          className="group inline-flex items-center gap-3 rounded-full border border-transparent bg-background/40 px-3 py-1 transition hover:border-border/70 hover:bg-background/70"
         >
-          <span className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-primary/15 text-sm font-bold uppercase tracking-tight text-primary">
+          <span className="inline-flex h-11 w-11 items-center justify-center rounded-full bg-primary/15 text-sm font-bold uppercase tracking-tight text-primary">
             RK
           </span>
           <span className="flex flex-col leading-tight">
@@ -57,10 +67,12 @@ export function NavigationBar({ primary, secondary, mobile }: NavigationBarProps
             <span className="text-xs font-medium text-muted-foreground">Estonian tasting rooms</span>
           </span>
         </Link>
-        <nav aria-label="Primary" className="hidden items-center gap-2 md:flex">
+
+        <nav aria-label="Primary" className="hidden items-center gap-1 md:flex">
           {primary.map((link) => {
             const active = isActivePath(pathname ?? "/", link.href);
             const emphasize = link.label.toLowerCase() === "reserve";
+
             return (
               <Link
                 key={link.id}
@@ -68,11 +80,12 @@ export function NavigationBar({ primary, secondary, mobile }: NavigationBarProps
                 aria-current={active ? "page" : undefined}
                 className={cn(
                   buttonClasses({
-                    variant: active ? "default" : emphasize ? "default" : "ghost",
+                    variant: active || emphasize ? "default" : "ghost",
                     size: "sm",
                   }),
                   "h-10 rounded-full px-5",
-                  !active && !emphasize && "text-muted-foreground",
+                  active && "ring-2 ring-primary/30",
+                  !active && !emphasize && "text-muted-foreground hover:text-foreground",
                 )}
               >
                 <span>{link.label}</span>
@@ -81,47 +94,153 @@ export function NavigationBar({ primary, secondary, mobile }: NavigationBarProps
             );
           })}
         </nav>
-        <nav aria-label="Secondary" className="hidden items-center gap-3 text-sm text-muted-foreground lg:flex">
-          {secondary.map((link) => {
-            const active = isActivePath(pathname ?? "/", link.href);
-            return (
-              <Link
-                key={link.id}
-                href={link.href}
-                aria-current={active ? "page" : undefined}
-                className={cn(
-                  "rounded-full px-3 py-2 transition hover:text-foreground",
-                  active && "bg-muted text-foreground",
-                )}
-              >
-                {link.label}
-              </Link>
-            );
-          })}
-        </nav>
+
+        <div className="hidden items-center gap-3 lg:flex">
+          <Separator orientation="vertical" className="h-6" />
+          <nav aria-label="Secondary" className="flex items-center gap-2 text-sm">
+            {secondary.map((link) => {
+              const active = isActivePath(pathname ?? "/", link.href);
+              return (
+                <Link
+                  key={link.id}
+                  href={link.href}
+                  aria-current={active ? "page" : undefined}
+                  className={cn(
+                    "rounded-full px-3 py-2 transition",
+                    active ? "bg-muted text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground",
+                  )}
+                >
+                  {link.label}
+                </Link>
+              );
+            })}
+          </nav>
+        </div>
+
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="relative -mr-2 h-10 w-10 md:hidden"
+          aria-expanded={mobileOpen}
+          aria-label={mobileOpen ? "Close navigation" : "Open navigation"}
+          onClick={() => setMobileOpen((value) => !value)}
+        >
+          <span className="sr-only">Toggle navigation</span>
+          <span
+            className={cn(
+              "absolute h-0.5 w-6 rounded-full bg-foreground transition-all",
+              mobileOpen ? "translate-y-0 rotate-45" : "-translate-y-2",
+            )}
+          />
+          <span
+            className={cn(
+              "absolute h-0.5 w-6 rounded-full bg-foreground transition-all",
+              mobileOpen ? "opacity-0" : "opacity-100",
+            )}
+          />
+          <span
+            className={cn(
+              "absolute h-0.5 w-6 rounded-full bg-foreground transition-all",
+              mobileOpen ? "translate-y-0 -rotate-45" : "translate-y-2",
+            )}
+          />
+        </Button>
       </div>
-      <nav
-        aria-label="Mobile"
-        className="flex items-center justify-around border-t border-border/60 bg-background px-2 py-3 md:hidden"
-      >
-        {mobile.map((link) => {
-          const active = isActivePath(pathname ?? "/", link.href);
-          return (
-            <Link
-              key={link.id}
-              href={link.href}
-              aria-current={active ? "page" : undefined}
-              className={cn(
-                "flex min-w-0 flex-col items-center gap-1 rounded-full px-3 py-2 text-xs font-medium transition",
-                active ? "text-foreground" : "text-muted-foreground hover:text-foreground",
-              )}
-            >
-              <span>{link.label}</span>
-              {link.badge ? <span className="text-[10px] uppercase tracking-widest text-primary">{link.badge}</span> : null}
-            </Link>
-          );
-        })}
-      </nav>
+
+      {mobileOpen ? (
+        <div className="border-t border-border/60 bg-background/95 shadow-lg md:hidden" role="dialog" aria-modal>
+          <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-6 py-6">
+            <div className="grid gap-2">
+              {primary.map((link) => {
+                const active = isActivePath(pathname ?? "/", link.href);
+                const emphasize = link.label.toLowerCase() === "reserve";
+                return (
+                  <Link
+                    key={link.id}
+                    href={link.href}
+                    aria-current={active ? "page" : undefined}
+                    className={cn(
+                      "flex items-center justify-between rounded-2xl border border-border/60 px-4 py-3 text-sm font-semibold transition",
+                      active
+                        ? "bg-primary text-primary-foreground shadow-sm"
+                        : emphasize
+                          ? "bg-primary/10 text-primary hover:bg-primary/20"
+                          : "bg-muted/40 text-foreground hover:bg-muted",
+                    )}
+                  >
+                    <span>{link.label}</span>
+                    {link.badge ? <Badge>{link.badge}</Badge> : null}
+                  </Link>
+                );
+              })}
+            </div>
+
+            {secondary.length ? (
+              <div className="space-y-3">
+                <div className="flex items-center justify-between">
+                  <span className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+                    Discover
+                  </span>
+                  <Separator className="flex-1" />
+                </div>
+                <div className="grid gap-2">
+                  {secondary.map((link) => {
+                    const active = isActivePath(pathname ?? "/", link.href);
+                    return (
+                      <Link
+                        key={link.id}
+                        href={link.href}
+                        aria-current={active ? "page" : undefined}
+                        className={cn(
+                          "rounded-2xl px-4 py-3 text-sm font-medium transition",
+                          active ? "bg-muted text-foreground" : "text-muted-foreground hover:bg-muted/60 hover:text-foreground",
+                        )}
+                      >
+                        {link.label}
+                      </Link>
+                    );
+                  })}
+                </div>
+              </div>
+            ) : null}
+
+            {mobile.length ? (
+              <div className="space-y-3">
+                <div className="flex items-center justify-between">
+                  <span className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+                    Quick links
+                  </span>
+                  <Separator className="flex-1" />
+                </div>
+                <div className="grid gap-2">
+                  {mobile.map((link) => {
+                    const active = isActivePath(pathname ?? "/", link.href);
+                    return (
+                      <Link
+                        key={link.id}
+                        href={link.href}
+                        aria-current={active ? "page" : undefined}
+                        className={cn(
+                          "rounded-2xl border border-border/50 px-4 py-3 text-sm font-medium transition",
+                          active
+                            ? "bg-primary/10 text-primary"
+                            : "text-muted-foreground hover:border-border hover:bg-muted/40 hover:text-foreground",
+                        )}
+                      >
+                        <div className="flex items-center justify-between gap-3">
+                          <span>{link.label}</span>
+                          {link.badge ? <Badge variant="outline">{link.badge}</Badge> : null}
+                        </div>
+                      </Link>
+                    );
+                  })}
+                </div>
+              </div>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
     </header>
   );
 }


### PR DESCRIPTION
## Summary
- redesign the primary navigation with a glassy shadcn treatment, mobile sheet, and richer grouping
- rebuild the Gift Cards, Catering, Events, Careers, FAQ, Privacy, and Terms pages with shadcn cards, badges, and structured content
- add curated copy blocks and prominent calls-to-action tailored to guests, teams, and corporate visitors

## Testing
- `npm test` *(fails: vitest not found in PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68e39d92bc0883219e651059bf1e62ab