### PR TITLE
Add persistent mobile nav tabs to site header

### DIFF
--- a/src/app/(marketing)/layout.tsx
+++ b/src/app/(marketing)/layout.tsx
@@ -9,7 +9,7 @@ export default function MarketingLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="flex min-h-screen flex-col bg-neutral-50 text-neutral-900">
+    <div className="flex min-h-screen flex-col bg-neutral-50 pb-24 text-neutral-900 md:pb-0">
       <Suspense fallback={<SkeletonHeader />}>
         <SiteHeader />
       </Suspense>

--- a/src/app/(transactions)/layout.tsx
+++ b/src/app/(transactions)/layout.tsx
@@ -9,7 +9,7 @@ export default function TransactionsLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="flex min-h-screen flex-col bg-neutral-50 text-neutral-900">
+    <div className="flex min-h-screen flex-col bg-neutral-50 pb-24 text-neutral-900 md:pb-0">
       <Suspense fallback={<SkeletonHeader />}>
         <SiteHeader />
       </Suspense>

--- a/src/components/navigation/navigation-bar.tsx
+++ b/src/components/navigation/navigation-bar.tsx
@@ -49,198 +49,242 @@ export function NavigationBar({ primary, secondary, mobile }: NavigationBarProps
   }, [pathname]);
 
   return (
-    <header className="sticky top-0 z-50 border-b border-border/60 bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-      <div
-        className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-primary/50 to-transparent"
-        aria-hidden
-      />
-      <div className="relative mx-auto flex h-20 w-full max-w-6xl items-center justify-between gap-4 px-6">
-        <Link
-          href="/"
-          className="group inline-flex items-center gap-3 rounded-full border border-transparent bg-background/40 px-3 py-1 transition hover:border-border/70 hover:bg-background/70"
-        >
-          <span className="inline-flex h-11 w-11 items-center justify-center rounded-full bg-primary/15 text-sm font-bold uppercase tracking-tight text-primary">
-            RK
-          </span>
-          <span className="flex flex-col leading-tight">
-            <span className="text-base font-semibold text-foreground">Restoran Kiisi</span>
-            <span className="text-xs font-medium text-muted-foreground">Estonian tasting rooms</span>
-          </span>
-        </Link>
+    <>
+      <header className="sticky top-0 z-50 border-b border-border/60 bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+        <div
+          className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-primary/50 to-transparent"
+          aria-hidden
+        />
+        <div className="relative mx-auto flex h-20 w-full max-w-6xl items-center justify-between gap-4 px-6">
+          <Link
+            href="/"
+            className="group inline-flex items-center gap-3 rounded-full border border-transparent bg-background/40 px-3 py-1 transition hover:border-border/70 hover:bg-background/70"
+          >
+            <span className="inline-flex h-11 w-11 items-center justify-center rounded-full bg-primary/15 text-sm font-bold uppercase tracking-tight text-primary">
+              RK
+            </span>
+            <span className="flex flex-col leading-tight">
+              <span className="text-base font-semibold text-foreground">Restoran Kiisi</span>
+              <span className="text-xs font-medium text-muted-foreground">Estonian tasting rooms</span>
+            </span>
+          </Link>
 
-        <nav aria-label="Primary" className="hidden items-center gap-1 md:flex">
-          {primary.map((link) => {
-            const active = isActivePath(pathname ?? "/", link.href);
-            const emphasize = link.label.toLowerCase() === "reserve";
-
-            return (
-              <Link
-                key={link.id}
-                href={link.href}
-                aria-current={active ? "page" : undefined}
-                className={cn(
-                  buttonClasses({
-                    variant: active || emphasize ? "default" : "ghost",
-                    size: "sm",
-                  }),
-                  "h-10 rounded-full px-5",
-                  active && "ring-2 ring-primary/30",
-                  !active && !emphasize && "text-muted-foreground hover:text-foreground",
-                )}
-              >
-                <span>{link.label}</span>
-                {link.badge ? <Badge variant="outline">{link.badge}</Badge> : null}
-              </Link>
-            );
-          })}
-        </nav>
-
-        <div className="hidden items-center gap-3 lg:flex">
-          <Separator orientation="vertical" className="h-6" />
-          <nav aria-label="Secondary" className="flex items-center gap-2 text-sm">
-            {secondary.map((link) => {
+          <nav aria-label="Primary" className="hidden items-center gap-1 md:flex">
+            {primary.map((link) => {
               const active = isActivePath(pathname ?? "/", link.href);
+              const emphasize = link.label.toLowerCase() === "reserve";
+
               return (
                 <Link
                   key={link.id}
                   href={link.href}
                   aria-current={active ? "page" : undefined}
                   className={cn(
-                    "rounded-full px-3 py-2 transition",
-                    active ? "bg-muted text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground",
+                    buttonClasses({
+                      variant: active || emphasize ? "default" : "ghost",
+                      size: "sm",
+                    }),
+                    "h-10 rounded-full px-5",
+                    active && "ring-2 ring-primary/30",
+                    !active && !emphasize && "text-muted-foreground hover:text-foreground",
                   )}
                 >
-                  {link.label}
+                  <span>{link.label}</span>
+                  {link.badge ? <Badge variant="outline">{link.badge}</Badge> : null}
                 </Link>
               );
             })}
           </nav>
-        </div>
 
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          className="relative -mr-2 h-10 w-10 md:hidden"
-          aria-expanded={mobileOpen}
-          aria-label={mobileOpen ? "Close navigation" : "Open navigation"}
-          onClick={() => setMobileOpen((value) => !value)}
-        >
-          <span className="sr-only">Toggle navigation</span>
-          <span
-            className={cn(
-              "absolute h-0.5 w-6 rounded-full bg-foreground transition-all",
-              mobileOpen ? "translate-y-0 rotate-45" : "-translate-y-2",
-            )}
-          />
-          <span
-            className={cn(
-              "absolute h-0.5 w-6 rounded-full bg-foreground transition-all",
-              mobileOpen ? "opacity-0" : "opacity-100",
-            )}
-          />
-          <span
-            className={cn(
-              "absolute h-0.5 w-6 rounded-full bg-foreground transition-all",
-              mobileOpen ? "translate-y-0 -rotate-45" : "translate-y-2",
-            )}
-          />
-        </Button>
-      </div>
-
-      {mobileOpen ? (
-        <div className="border-t border-border/60 bg-background/95 shadow-lg md:hidden" role="dialog" aria-modal>
-          <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-6 py-6">
-            <div className="grid gap-2">
-              {primary.map((link) => {
+          <div className="hidden items-center gap-3 lg:flex">
+            <Separator orientation="vertical" className="h-6" />
+            <nav aria-label="Secondary" className="flex items-center gap-2 text-sm">
+              {secondary.map((link) => {
                 const active = isActivePath(pathname ?? "/", link.href);
-                const emphasize = link.label.toLowerCase() === "reserve";
                 return (
                   <Link
                     key={link.id}
                     href={link.href}
                     aria-current={active ? "page" : undefined}
                     className={cn(
-                      "flex items-center justify-between rounded-2xl border border-border/60 px-4 py-3 text-sm font-semibold transition",
-                      active
-                        ? "bg-primary text-primary-foreground shadow-sm"
-                        : emphasize
-                          ? "bg-primary/10 text-primary hover:bg-primary/20"
-                          : "bg-muted/40 text-foreground hover:bg-muted",
+                      "rounded-full px-3 py-2 transition",
+                      active ? "bg-muted text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground",
                     )}
                   >
-                    <span>{link.label}</span>
-                    {link.badge ? <Badge>{link.badge}</Badge> : null}
+                    {link.label}
                   </Link>
                 );
               })}
-            </div>
-
-            {secondary.length ? (
-              <div className="space-y-3">
-                <div className="flex items-center justify-between">
-                  <span className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
-                    Discover
-                  </span>
-                  <Separator className="flex-1" />
-                </div>
-                <div className="grid gap-2">
-                  {secondary.map((link) => {
-                    const active = isActivePath(pathname ?? "/", link.href);
-                    return (
-                      <Link
-                        key={link.id}
-                        href={link.href}
-                        aria-current={active ? "page" : undefined}
-                        className={cn(
-                          "rounded-2xl px-4 py-3 text-sm font-medium transition",
-                          active ? "bg-muted text-foreground" : "text-muted-foreground hover:bg-muted/60 hover:text-foreground",
-                        )}
-                      >
-                        {link.label}
-                      </Link>
-                    );
-                  })}
-                </div>
-              </div>
-            ) : null}
-
-            {mobile.length ? (
-              <div className="space-y-3">
-                <div className="flex items-center justify-between">
-                  <span className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
-                    Quick links
-                  </span>
-                  <Separator className="flex-1" />
-                </div>
-                <div className="grid gap-2">
-                  {mobile.map((link) => {
-                    const active = isActivePath(pathname ?? "/", link.href);
-                    return (
-                      <Link
-                        key={link.id}
-                        href={link.href}
-                        aria-current={active ? "page" : undefined}
-                        className={cn(
-                          "rounded-2xl border border-border/50 px-4 py-3 text-sm font-medium transition",
-                          active
-                            ? "bg-primary/10 text-primary"
-                            : "text-muted-foreground hover:border-border hover:bg-muted/40 hover:text-foreground",
-                        )}
-                      >
-                        <div className="flex items-center justify-between gap-3">
-                          <span>{link.label}</span>
-                          {link.badge ? <Badge variant="outline">{link.badge}</Badge> : null}
-                        </div>
-                      </Link>
-                    );
-                  })}
-                </div>
-              </div>
-            ) : null}
+            </nav>
           </div>
+
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="relative -mr-2 h-10 w-10 md:hidden"
+            aria-expanded={mobileOpen}
+            aria-label={mobileOpen ? "Close navigation" : "Open navigation"}
+            onClick={() => setMobileOpen((value) => !value)}
+          >
+            <span className="sr-only">Toggle navigation</span>
+            <span
+              className={cn(
+                "absolute h-0.5 w-6 rounded-full bg-foreground transition-all",
+                mobileOpen ? "translate-y-0 rotate-45" : "-translate-y-2",
+              )}
+            />
+            <span
+              className={cn(
+                "absolute h-0.5 w-6 rounded-full bg-foreground transition-all",
+                mobileOpen ? "opacity-0" : "opacity-100",
+              )}
+            />
+            <span
+              className={cn(
+                "absolute h-0.5 w-6 rounded-full bg-foreground transition-all",
+                mobileOpen ? "translate-y-0 -rotate-45" : "translate-y-2",
+              )}
+            />
+          </Button>
         </div>
+
+        {mobileOpen ? (
+          <div className="border-t border-border/60 bg-background/95 shadow-lg md:hidden" role="dialog" aria-modal>
+            <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-6 py-6">
+              <div className="grid gap-2">
+                {primary.map((link) => {
+                  const active = isActivePath(pathname ?? "/", link.href);
+                  const emphasize = link.label.toLowerCase() === "reserve";
+                  return (
+                    <Link
+                      key={link.id}
+                      href={link.href}
+                      aria-current={active ? "page" : undefined}
+                      className={cn(
+                        "flex items-center justify-between rounded-2xl border border-border/60 px-4 py-3 text-sm font-semibold transition",
+                        active
+                          ? "bg-primary text-primary-foreground shadow-sm"
+                          : emphasize
+                            ? "bg-primary/10 text-primary hover:bg-primary/20"
+                            : "bg-muted/40 text-foreground hover:bg-muted",
+                      )}
+                    >
+                      <span>{link.label}</span>
+                      {link.badge ? <Badge>{link.badge}</Badge> : null}
+                    </Link>
+                  );
+                })}
+              </div>
+
+              {secondary.length ? (
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between">
+                    <span className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+                      Discover
+                    </span>
+                    <Separator className="flex-1" />
+                  </div>
+                  <div className="grid gap-2">
+                    {secondary.map((link) => {
+                      const active = isActivePath(pathname ?? "/", link.href);
+                      return (
+                        <Link
+                          key={link.id}
+                          href={link.href}
+                          aria-current={active ? "page" : undefined}
+                          className={cn(
+                            "rounded-2xl px-4 py-3 text-sm font-medium transition",
+                            active
+                              ? "bg-muted text-foreground"
+                              : "text-muted-foreground hover:bg-muted/60 hover:text-foreground",
+                          )}
+                        >
+                          {link.label}
+                        </Link>
+                      );
+                    })}
+                  </div>
+                </div>
+              ) : null}
+
+              {mobile.length ? (
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between">
+                    <span className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+                      Quick links
+                    </span>
+                    <Separator className="flex-1" />
+                  </div>
+                  <div className="grid gap-2">
+                    {mobile.map((link) => {
+                      const active = isActivePath(pathname ?? "/", link.href);
+                      return (
+                        <Link
+                          key={link.id}
+                          href={link.href}
+                          aria-current={active ? "page" : undefined}
+                          className={cn(
+                            "rounded-2xl border border-border/50 px-4 py-3 text-sm font-medium transition",
+                            active
+                              ? "bg-primary/10 text-primary"
+                              : "text-muted-foreground hover:border-border hover:bg-muted/40 hover:text-foreground",
+                          )}
+                        >
+                          <div className="flex items-center justify-between gap-3">
+                            <span>{link.label}</span>
+                            {link.badge ? <Badge variant="outline">{link.badge}</Badge> : null}
+                          </div>
+                        </Link>
+                      );
+                    })}
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          </div>
+        ) : null}
+      </header>
+
+      {mobile.length ? (
+        <nav
+          aria-label="Mobile navigation"
+          className="fixed inset-x-0 bottom-0 z-40 border-t border-border/70 bg-background/95 pb-[env(safe-area-inset-bottom)] pb-2 pt-1 shadow-[0_-6px_18px_rgba(15,23,42,0.08)] backdrop-blur md:hidden"
+        >
+          <div className="mx-auto flex max-w-6xl items-stretch justify-between px-2 py-1">
+            {mobile.map((link) => {
+              const active = isActivePath(pathname ?? "/", link.href);
+              return (
+                <Link
+                  key={`mobile-tab-${link.id}`}
+                  href={link.href}
+                  aria-current={active ? "page" : undefined}
+                  className={cn(
+                    "flex flex-1 flex-col items-center gap-1 rounded-2xl px-3 py-2 text-xs font-medium transition",
+                    active
+                      ? "bg-primary/10 text-primary"
+                      : "text-muted-foreground hover:text-foreground",
+                  )}
+                >
+                  <span>{link.label}</span>
+                  {link.badge ? (
+                    <Badge variant="outline" className="text-[10px]">
+                      {link.badge}
+                    </Badge>
+                  ) : null}
+                  <span
+                    className={cn(
+                      "mt-1 h-1 w-8 rounded-full transition",
+                      active ? "bg-primary" : "bg-transparent",
+                    )}
+                    aria-hidden
+                  />
+                </Link>
+              );
+            })}
+          </div>
+        </nav>
       ) : null}
-    </header>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- introduce a fixed mobile tab navigation inside the site header so primary journeys stay accessible
- pad marketing and transaction layouts so page content and footer are not obscured by the mobile nav bar

## Testing
- npx vitest run tests/components/navigation-bar.test.tsx *(fails: npm registry access is forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3a22f1d508321b4c344e85a4c41f5