### PR TITLE
feat: refresh account and offers with shadcn ui

### DIFF
--- a/src/app/(marketing)/offers/page.tsx
+++ b/src/app/(marketing)/offers/page.tsx
@@ -1,63 +1,119 @@
-﻿import { Suspense } from 'react';
+import { Suspense } from "react";
 
-import { getPromotions } from '@/lib/data';
-import { SkeletonSection } from '@/components/navigation/skeletons';
+import { Badge } from "@/components/ui/badge";
+import { buttonClasses } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { SkeletonSection } from "@/components/navigation/skeletons";
+import { getPromotions } from "@/lib/data";
+
+const audienceStyles = {
+  CATERING: {
+    label: "Catering",
+    badgeClass: "bg-accent/10 text-accent border-accent/30",
+  },
+  LOYALTY: {
+    label: "Loyalty",
+    badgeClass: "bg-primary/10 text-primary border-primary/30",
+  },
+  PUBLIC: {
+    label: "Signature experience",
+    badgeClass: "bg-secondary text-secondary-foreground border-secondary/60",
+  },
+} as const;
 
 async function OffersContent() {
   const promotions = await getPromotions();
 
   if (promotions.length === 0) {
     return (
-      <div className="mx-auto max-w-3xl px-6 py-12 text-center">
-        <h1 className="text-3xl font-semibold">No active offers</h1>
-        <p className="mt-4 text-sm text-neutral-500">
-          Check back soon for seasonal tasting menus and special events.
-        </p>
+      <div className="relative mx-auto max-w-4xl px-6 py-20">
+        <div className="pointer-events-none absolute inset-x-12 top-12 h-48 rounded-full bg-primary/10 blur-3xl" />
+        <Card className="relative overflow-hidden border-none bg-card shadow-xl shadow-primary/10">
+          <div className="pointer-events-none absolute -right-24 top-0 h-56 w-56 rounded-full bg-accent/15 blur-3xl" />
+          <CardHeader className="relative space-y-3 text-center">
+            <CardTitle className="text-3xl">No active offers</CardTitle>
+            <CardDescription className="mx-auto max-w-2xl text-base">
+              Check back soon for seasonal tasting menus, chef collaborations, and intimate dining events crafted for our guests.
+            </CardDescription>
+          </CardHeader>
+          <CardFooter className="justify-center border-t border-border/60 bg-muted/40 px-10 py-6 text-sm text-muted-foreground">
+            Be the first to know by subscribing to updates in your Kiisi account.
+          </CardFooter>
+        </Card>
       </div>
     );
   }
 
   return (
-    <div className="mx-auto max-w-6xl space-y-8 px-6 py-12">
-      <header className="space-y-2">
-        <h1 className="text-3xl font-semibold">Offers & Events</h1>
-        <p className="text-sm text-neutral-500">
-          Discover tasting menus, holiday celebrations, and catering specials from Restoran Kiisi.
-        </p>
-      </header>
-      <div className="grid gap-6 md:grid-cols-2">
-        {promotions.map((promotion) => (
-          <article key={promotion.id} className="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
-            <p className="text-xs uppercase tracking-wide text-neutral-400">
-              {promotion.audience === 'CATERING' ? 'Catering' : promotion.audience === 'LOYALTY' ? 'Loyalty' : 'Public offer'}
-            </p>
-            <h2 className="mt-2 text-xl font-semibold text-neutral-900">{promotion.title}</h2>
-            {promotion.subtitle ? (
-              <p className="mt-1 text-sm text-neutral-500">{promotion.subtitle}</p>
-            ) : null}
-            {promotion.body ? (
-              <p className="mt-4 text-sm leading-6 text-neutral-600">{promotion.body}</p>
-            ) : null}
-            <dl className="mt-4 text-xs text-neutral-500">
-              <div className="flex gap-2">
-                <dt className="font-medium">Starts:</dt>
-                <dd>{new Date(promotion.startAt).toLocaleDateString()}</dd>
-              </div>
-              <div className="flex gap-2">
-                <dt className="font-medium">Ends:</dt>
-                <dd>{new Date(promotion.endAt).toLocaleDateString()}</dd>
-              </div>
-            </dl>
-            {promotion.ctaUrl ? (
-              <a
-                href={promotion.ctaUrl}
-                className="mt-6 inline-flex items-center text-sm font-medium text-amber-600 hover:text-amber-700"
-              >
-                {promotion.ctaLabel ?? 'Learn more'}
-              </a>
-            ) : null}
-          </article>
-        ))}
+    <div className="relative mx-auto max-w-6xl space-y-12 px-6 py-16">
+      <div className="pointer-events-none absolute inset-x-10 -top-12 h-64 rounded-full bg-primary/10 blur-3xl" />
+      <Card className="relative overflow-hidden border-none bg-gradient-to-br from-primary/15 via-card to-card shadow-2xl shadow-primary/20">
+        <div className="pointer-events-none absolute -right-24 top-0 h-56 w-56 rounded-full bg-accent/20 blur-3xl" />
+        <CardHeader className="relative space-y-3">
+          <Badge className="w-fit border-primary/30 bg-primary/10 text-primary">Seasonal highlights</Badge>
+          <CardTitle className="text-3xl md:text-4xl">Offers &amp; Events</CardTitle>
+          <CardDescription className="max-w-2xl text-base">
+            Discover tasting menus, holiday celebrations, and tailored catering experiences from Restoran Kiisi.
+          </CardDescription>
+        </CardHeader>
+        <CardFooter className="relative border-t border-white/40 bg-white/40 px-8 py-6 text-sm text-muted-foreground backdrop-blur">
+          Delight your guests and teams with curated Estonian flavours, available across Tallinn and beyond.
+        </CardFooter>
+      </Card>
+      <div className="grid gap-8 md:grid-cols-2">
+        {promotions.map((promotion) => {
+          const audience = audienceStyles[promotion.audience as keyof typeof audienceStyles] ?? audienceStyles.PUBLIC;
+
+          return (
+            <Card
+              key={promotion.id}
+              className="relative overflow-hidden border-none bg-card shadow-xl shadow-primary/10 transition hover:-translate-y-1 hover:shadow-primary/20"
+            >
+              <div className="pointer-events-none absolute -right-16 top-0 h-40 w-40 rounded-full bg-primary/10 blur-3xl" />
+              <CardHeader className="relative space-y-3">
+                <Badge variant="outline" className={`w-fit border ${audience.badgeClass}`}>
+                  {audience.label}
+                </Badge>
+                <CardTitle className="text-2xl leading-tight text-foreground">{promotion.title}</CardTitle>
+                {promotion.subtitle ? (
+                  <CardDescription className="text-base text-foreground/80">{promotion.subtitle}</CardDescription>
+                ) : null}
+              </CardHeader>
+              <CardContent className="relative space-y-5">
+                {promotion.body ? (
+                  <p className="text-sm leading-6 text-muted-foreground">{promotion.body}</p>
+                ) : null}
+                <dl className="grid gap-2 text-xs text-muted-foreground">
+                  <div className="flex justify-between gap-2">
+                    <dt className="font-medium uppercase tracking-[0.18em] text-foreground/80">Starts</dt>
+                    <dd>{new Date(promotion.startAt).toLocaleDateString()}</dd>
+                  </div>
+                  <div className="flex justify-between gap-2">
+                    <dt className="font-medium uppercase tracking-[0.18em] text-foreground/80">Ends</dt>
+                    <dd>{new Date(promotion.endAt).toLocaleDateString()}</dd>
+                  </div>
+                </dl>
+              </CardContent>
+              {promotion.ctaUrl ? (
+                <CardFooter className="relative border-t border-border/60 bg-muted/40 px-6 py-5">
+                  <a
+                    href={promotion.ctaUrl}
+                    className={`${buttonClasses({ variant: "default", size: "sm" })} h-10 px-5`}
+                  >
+                    {promotion.ctaLabel ?? "Learn more"}
+                  </a>
+                </CardFooter>
+              ) : null}
+            </Card>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/app/(transactions)/account/account-form.tsx
+++ b/src/app/(transactions)/account/account-form.tsx
@@ -4,6 +4,13 @@ import { useTransition, useActionState } from "react";
 
 import type { GuestProfile } from "@prisma/client";
 
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select } from "@/components/ui/select";
+
 import { updateProfileAction } from "./account-actions";
 import { initialAccountState, type AccountFormState } from "./form-state";
 
@@ -20,125 +27,93 @@ export function AccountForm({ profile, locations }: AccountFormProps) {
   const [pending, startTransition] = useTransition();
 
   return (
-    <form
-      action={(formData) => startTransition(() => action(formData))}
-      className="grid gap-6 rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm"
-    >
-      <input type="hidden" name="profileId" value={profile.id} />
+    <form action={(formData) => startTransition(() => action(formData))}>
+      <Card className="border-none bg-card shadow-xl shadow-primary/10">
+        <CardHeader className="space-y-1 pb-4">
+          <CardTitle className="text-2xl">Profile details</CardTitle>
+          <CardDescription>
+            Update contact preferences, favourite locations, and security details for your Kiisi experiences.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <input type="hidden" name="profileId" value={profile.id} />
 
-      <div className="grid gap-2">
-        <label className="text-sm font-medium" htmlFor="email">
-          Email (sign-in)
-        </label>
-        <input
-          id="email"
-          name="email"
-          type="email"
-          required
-          defaultValue={profile.email}
-          className="rounded-lg border border-neutral-200 px-3 py-2 text-sm"
-        />
-      </div>
+          <div className="grid gap-2">
+            <Label htmlFor="email">Email (sign-in)</Label>
+            <Input id="email" name="email" type="email" required defaultValue={profile.email} />
+          </div>
 
-      <div className="grid gap-2 md:grid-cols-2">
-        <div className="grid gap-2">
-          <label className="text-sm font-medium" htmlFor="firstName">
-            First name
-          </label>
-          <input
-            id="firstName"
-            name="firstName"
-            defaultValue={profile.firstName ?? ""}
-            className="rounded-lg border border-neutral-200 px-3 py-2 text-sm"
-          />
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="grid gap-2">
+              <Label htmlFor="firstName">First name</Label>
+              <Input id="firstName" name="firstName" defaultValue={profile.firstName ?? ""} />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="lastName">Last name</Label>
+              <Input id="lastName" name="lastName" defaultValue={profile.lastName ?? ""} />
+            </div>
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="phone">Phone number</Label>
+            <Input id="phone" name="phone" defaultValue={profile.phone ?? ""} placeholder="e.g. +372 5555 5555" />
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="defaultLocation">Preferred location</Label>
+            <Select
+              id="defaultLocation"
+              name="defaultLocation"
+              defaultValue={profile.defaultLocationId ?? locations[0]?.slug}
+            >
+              {locations.map((location) => (
+                <option key={location.slug} value={location.slug}>
+                  {location.name}
+                </option>
+              ))}
+            </Select>
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="newPassword">New password (optional)</Label>
+            <Input
+              id="newPassword"
+              name="newPassword"
+              type="password"
+              placeholder="Leave blank to keep current password"
+            />
+          </div>
+
+          <div className="flex items-start gap-3 rounded-2xl border border-border/60 bg-muted/50 p-4">
+            <Checkbox id="marketingOptIn" name="marketingOptIn" defaultChecked={profile.marketingOptIn} />
+            <div className="space-y-1 text-sm">
+              <Label htmlFor="marketingOptIn" className="font-medium">
+                Seasonal offers and events
+              </Label>
+              <p className="text-muted-foreground">
+                Receive curated tasting menus, loyalty surprises, and early access to special happenings.
+              </p>
+            </div>
+          </div>
+
+          {state.status === "error" ? (
+            <div className="rounded-2xl border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+              {state.message}
+            </div>
+          ) : null}
+          {state.status === "success" ? (
+            <div className="rounded-2xl border border-emerald-400/40 bg-emerald-400/10 px-4 py-3 text-sm text-emerald-600">
+              Profile updated successfully.
+            </div>
+          ) : null}
+        </CardContent>
+        <div className="flex flex-col gap-3 border-t border-border/60 bg-muted/40 px-8 py-6 text-sm text-muted-foreground md:flex-row md:items-center md:justify-between">
+          <p>{pending ? "Saving your preferences..." : "Changes apply immediately across Kiisi experiences."}</p>
+          <Button type="submit" className="h-11 px-6" disabled={pending}>
+            {pending ? "Saving..." : "Save profile"}
+          </Button>
         </div>
-        <div className="grid gap-2">
-          <label className="text-sm font-medium" htmlFor="lastName">
-            Last name
-          </label>
-          <input
-            id="lastName"
-            name="lastName"
-            defaultValue={profile.lastName ?? ""}
-            className="rounded-lg border border-neutral-200 px-3 py-2 text-sm"
-          />
-        </div>
-      </div>
-
-      <div className="grid gap-2">
-        <label className="text-sm font-medium" htmlFor="phone">
-          Phone number
-        </label>
-        <input
-          id="phone"
-          name="phone"
-          defaultValue={profile.phone ?? ""}
-          className="rounded-lg border border-neutral-200 px-3 py-2 text-sm"
-        />
-      </div>
-
-      <div className="grid gap-2">
-        <label className="text-sm font-medium" htmlFor="defaultLocation">
-          Preferred location
-        </label>
-        <select
-          id="defaultLocation"
-          name="defaultLocation"
-          defaultValue={profile.defaultLocationId ?? locations[0]?.slug}
-          className="rounded-lg border border-neutral-200 px-3 py-2 text-sm"
-        >
-          {locations.map((location) => (
-            <option key={location.slug} value={location.slug}>
-              {location.name}
-            </option>
-          ))}
-        </select>
-      </div>
-
-      <div className="grid gap-2">
-        <label className="text-sm font-medium" htmlFor="newPassword">
-          New password (optional)
-        </label>
-        <input
-          id="newPassword"
-          name="newPassword"
-          type="password"
-          placeholder="Leave blank to keep current password"
-          className="rounded-lg border border-neutral-200 px-3 py-2 text-sm"
-        />
-      </div>
-
-      <div className="flex items-center gap-3">
-        <input
-          id="marketingOptIn"
-          name="marketingOptIn"
-          type="checkbox"
-          defaultChecked={profile.marketingOptIn}
-          className="h-4 w-4 rounded border border-neutral-300"
-        />
-        <label className="text-sm text-neutral-600" htmlFor="marketingOptIn">
-          Receive seasonal updates and special offers via email.
-        </label>
-      </div>
-
-      {state.status === "error" ? (
-        <div className="rounded-lg border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
-          {state.message}
-        </div>
-      ) : null}
-      {state.status === "success" ? (
-        <div className="rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">
-          Profile updated successfully.
-        </div>
-      ) : null}
-
-      <button
-        type="submit"
-        className="inline-flex items-center justify-center rounded-full bg-amber-600 px-6 py-3 text-sm font-semibold text-white shadow-sm hover:bg-amber-700 disabled:opacity-50"
-        disabled={pending}
-      >
-        {pending ? "Saving..." : "Save profile"}
-      </button>
+      </Card>
     </form>
   );
 }

--- a/src/app/(transactions)/account/page.tsx
+++ b/src/app/(transactions)/account/page.tsx
@@ -1,5 +1,14 @@
 ﻿import { cookies } from "next/headers";
 
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { auth } from "@/lib/auth";
 import { getLocations } from "@/lib/data";
 import { prisma } from "@/lib/prisma-client";
@@ -32,11 +41,8 @@ export default async function AccountPage() {
 
   if (!authenticatedEmail) {
     return (
-      <div className="mx-auto max-w-md space-y-6 px-6 py-12">
-        <header className="space-y-2 text-center">
-          <h1 className="text-3xl font-semibold text-neutral-900">Sign in to Kiisi</h1>
-          <p className="text-sm text-neutral-500">Access your reservations, preferences, and order history.</p>
-        </header>
+      <div className="relative mx-auto max-w-3xl px-6 py-16">
+        <div className="pointer-events-none absolute inset-x-10 top-10 h-48 rounded-full bg-primary/15 blur-3xl" />
         <AccountSignInForm />
       </div>
     );
@@ -76,74 +82,122 @@ export default async function AccountPage() {
   ]);
 
   return (
-    <div className="mx-auto max-w-4xl space-y-10 px-6 py-12">
-      <header className="space-y-3">
-        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-          <div className="space-y-2">
-            <h1 className="text-3xl font-semibold text-neutral-900">Your account</h1>
-            <p className="text-sm text-neutral-500">
-              Manage personal details, preferred location, and contact preferences.
-            </p>
-            <p className="text-sm font-medium text-neutral-900">Welcome back, {greetingName}!</p>
+    <div className="relative mx-auto max-w-6xl space-y-10 px-6 py-12">
+      <div className="pointer-events-none absolute inset-x-10 -top-12 h-64 rounded-full bg-primary/10 blur-3xl" />
+      <Card className="relative overflow-hidden border-none bg-gradient-to-br from-primary/15 via-card to-card shadow-2xl shadow-primary/20">
+        <div className="pointer-events-none absolute -right-24 top-0 h-56 w-56 rounded-full bg-accent/20 blur-3xl" />
+        <CardHeader className="relative z-10 flex flex-col gap-4 pb-6 md:flex-row md:items-center md:justify-between">
+          <div className="space-y-3">
+            <CardTitle className="text-3xl md:text-4xl">Your Kiisi account</CardTitle>
+            <CardDescription>
+              Manage personal details, preferred locations, and how we keep you in the loop about special moments.
+            </CardDescription>
+            <p className="text-sm font-medium text-foreground">Welcome back, {greetingName}!</p>
           </div>
           <AccountSignOutButton />
+        </CardHeader>
+        <CardFooter className="relative z-10 grid gap-4 border-t border-white/40 bg-white/40 px-8 py-6 text-sm text-muted-foreground backdrop-blur md:grid-cols-3">
+          <div className="space-y-1">
+            <p className="text-xs uppercase tracking-[0.24em]">Orders</p>
+            <p className="text-lg font-semibold text-foreground">{recentOrders.length}</p>
+            <p>Recorded moments of Kiisi at home.</p>
+          </div>
+          <div className="space-y-1">
+            <p className="text-xs uppercase tracking-[0.24em]">Reservations</p>
+            <p className="text-lg font-semibold text-foreground">{recentReservations.length}</p>
+            <p>Dining experiences planned with us.</p>
+          </div>
+          <div className="space-y-1">
+            <p className="text-xs uppercase tracking-[0.24em]">Updates</p>
+            <p className="text-lg font-semibold text-foreground">
+              {profile.marketingOptIn ? "Subscribed" : "Not subscribed"}
+            </p>
+            <p>{profile.marketingOptIn ? "You're on the list for seasonal news." : "Opt in below to hear about new menus."}</p>
+          </div>
+        </CardFooter>
+      </Card>
+      <div className="grid gap-8 lg:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]">
+        <AccountForm
+          profile={profile}
+          locations={locations.map((location) => ({ slug: location.slug, name: location.name }))}
+        />
+        <div className="space-y-6">
+          <Card className="border-none bg-card shadow-xl shadow-primary/10">
+            <CardHeader>
+              <CardTitle className="text-xl">Recent orders</CardTitle>
+              <CardDescription>Revisit your latest takeaway celebrations from Kiisi.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              {recentOrders.length === 0 ? (
+                <div className="flex flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-border/70 bg-muted/30 px-6 py-10 text-center text-sm text-muted-foreground">
+                  <p>No orders yet. Ready for your first takeaway feast?</p>
+                </div>
+              ) : (
+                <ul className="space-y-4 text-sm text-muted-foreground">
+                  {recentOrders.map((order) => (
+                    <li
+                      key={order.id}
+                      className="rounded-2xl border border-border/60 bg-gradient-to-br from-card via-card to-primary/5 p-5 shadow-sm shadow-primary/10"
+                    >
+                      <div className="flex flex-wrap items-start justify-between gap-3">
+                        <div className="space-y-1">
+                          <p className="text-base font-semibold text-foreground">{order.location.name}</p>
+                          <p className="text-xs text-muted-foreground">
+                            {new Date(order.createdAt).toLocaleString()} · {order.serviceType.toLowerCase()}
+                          </p>
+                        </div>
+                        <Badge variant="outline" className="rounded-xl border-primary/40 bg-primary/10 px-3 py-1 text-sm font-semibold text-primary">
+                          EUR {formatCurrency(order.total)}
+                        </Badge>
+                      </div>
+                      <div className="mt-3 flex items-center justify-between text-xs text-muted-foreground">
+                        <span>Status</span>
+                        <Badge variant="subtle" className="rounded-lg px-3 py-1 capitalize">
+                          {order.status.toLowerCase()}
+                        </Badge>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </CardContent>
+          </Card>
+          <Card className="border-none bg-card shadow-xl shadow-primary/10">
+            <CardHeader>
+              <CardTitle className="text-xl">Reservations</CardTitle>
+              <CardDescription>Track your upcoming and past dining room experiences.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              {recentReservations.length === 0 ? (
+                <div className="flex flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-border/70 bg-muted/30 px-6 py-10 text-center text-sm text-muted-foreground">
+                  <p>No reservations booked yet. We would love to host you soon.</p>
+                </div>
+              ) : (
+                <ul className="space-y-4 text-sm text-muted-foreground">
+                  {recentReservations.map((reservation) => (
+                    <li
+                      key={reservation.id}
+                      className="rounded-2xl border border-border/60 bg-gradient-to-br from-card via-card to-accent/5 p-5 shadow-sm shadow-accent/10"
+                    >
+                      <div className="flex flex-wrap items-start justify-between gap-3">
+                        <div className="space-y-1">
+                          <p className="text-base font-semibold text-foreground">{reservation.location.name}</p>
+                          <p className="text-xs text-muted-foreground">
+                            {new Date(reservation.requestedAt).toLocaleString()} · Party of {reservation.partySize}
+                          </p>
+                        </div>
+                        <Badge variant="outline" className="rounded-xl border-accent/40 bg-accent/10 px-3 py-1 text-sm font-semibold text-accent">
+                          {reservation.status.toLowerCase()}
+                        </Badge>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </CardContent>
+          </Card>
         </div>
-      </header>
-      <AccountForm
-        profile={profile}
-        locations={locations.map((location) => ({ slug: location.slug, name: location.name }))}
-      />
-      <section className="space-y-4">
-        <h2 className="text-lg font-semibold text-neutral-900">Recent orders</h2>
-        {recentOrders.length === 0 ? (
-          <p className="text-sm text-neutral-500">No orders yet. Ready for your first takeaway?</p>
-        ) : (
-          <ul className="space-y-3 text-sm text-neutral-600">
-            {recentOrders.map((order) => (
-              <li key={order.id} className="rounded-lg border border-neutral-200 bg-white px-4 py-3">
-                <div className="flex items-center justify-between">
-                  <div>
-                    <p className="font-medium text-neutral-900">{order.location.name}</p>
-                    <p className="text-xs text-neutral-500">
-                      {new Date(order.createdAt).toLocaleString()} - {order.serviceType.toLowerCase()}
-                    </p>
-                  </div>
-                  <p className="text-sm font-semibold text-neutral-900">
-                    EUR {formatCurrency(order.total)}
-                  </p>
-                </div>
-                <p className="mt-2 text-xs uppercase tracking-wide text-neutral-500">
-                  Status: {order.status.toLowerCase()}
-                </p>
-              </li>
-            ))}
-          </ul>
-        )}
-      </section>
-      <section className="space-y-4">
-        <h2 className="text-lg font-semibold text-neutral-900">Reservations</h2>
-        {recentReservations.length === 0 ? (
-          <p className="text-sm text-neutral-500">No reservations booked yet.</p>
-        ) : (
-          <ul className="space-y-3 text-sm text-neutral-600">
-            {recentReservations.map((reservation) => (
-              <li key={reservation.id} className="rounded-lg border border-neutral-200 bg-white px-4 py-3">
-                <div className="flex items-center justify-between">
-                  <div>
-                    <p className="font-medium text-neutral-900">{reservation.location.name}</p>
-                    <p className="text-xs text-neutral-500">
-                      {new Date(reservation.requestedAt).toLocaleString()} - Party of {reservation.partySize}
-                    </p>
-                  </div>
-                  <span className="text-xs uppercase tracking-wide text-neutral-500">
-                    {reservation.status.toLowerCase()}
-                  </span>
-                </div>
-              </li>
-            ))}
-          </ul>
-        )}
-      </section>
+      </div>
     </div>
   );
 }

--- a/src/app/(transactions)/account/sign-in-form.tsx
+++ b/src/app/(transactions)/account/sign-in-form.tsx
@@ -3,6 +3,11 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
 import { signInAccountAction } from "./account-actions";
 
 export function AccountSignInForm() {
@@ -40,55 +45,49 @@ export function AccountSignInForm() {
   }
 
   return (
-    <form
-      onSubmit={handleSubmit}
-      className="mx-auto grid max-w-md gap-4 rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm"
-    >
-      <div className="grid gap-2">
-        <label className="text-sm font-medium" htmlFor="email">
-          Email
-        </label>
-        <input
-          id="email"
-          name="email"
-          type="email"
-          autoComplete="email"
-          required
-          className="rounded-lg border border-neutral-200 px-3 py-2 text-sm"
-        />
-      </div>
-      <div className="grid gap-2">
-        <label className="text-sm font-medium" htmlFor="password">
-          Password
-        </label>
-        <input
-          id="password"
-          name="password"
-          type="password"
-          autoComplete="current-password"
-          required
-          className="rounded-lg border border-neutral-200 px-3 py-2 text-sm"
-        />
-      </div>
-      {error ? (
-        <div
-          role="alert"
-          aria-live="assertive"
-          className="rounded-lg border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700"
-        >
-          {error}
-        </div>
-      ) : null}
-      <button
-        type="submit"
-        className="inline-flex items-center justify-center rounded-full bg-amber-600 px-6 py-3 text-sm font-semibold text-white shadow-sm hover:bg-amber-700 disabled:opacity-60"
-        disabled={pending}
-      >
-        {pending ? "Signing in..." : "Sign in"}
-      </button>
-      {signedIn ? (
-        <p className="text-sm text-neutral-600" aria-live="polite">Welcome back! Loading your account...</p>
-      ) : null}
-    </form>
+    <Card className="relative overflow-hidden border-none bg-card shadow-xl shadow-primary/10">
+      <div className="pointer-events-none absolute -right-20 -top-20 h-48 w-48 rounded-full bg-primary/10 blur-3xl" />
+      <CardHeader className="relative space-y-2 pb-2">
+        <CardTitle className="text-2xl">Sign in to Kiisi</CardTitle>
+        <CardDescription>
+          Access reservations, preferences, and loyalty perks with your Kiisi account.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="grid gap-5">
+          <div className="grid gap-2">
+            <Label htmlFor="email">Email</Label>
+            <Input id="email" name="email" type="email" autoComplete="email" required />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="password">Password</Label>
+            <Input
+              id="password"
+              name="password"
+              type="password"
+              autoComplete="current-password"
+              required
+            />
+          </div>
+          {error ? (
+            <div
+              role="alert"
+              aria-live="assertive"
+              className="rounded-2xl border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive"
+            >
+              {error}
+            </div>
+          ) : null}
+          <Button type="submit" className="h-12" disabled={pending}>
+            {pending ? "Signing in..." : "Sign in"}
+          </Button>
+          {signedIn ? (
+            <p className="text-sm text-muted-foreground" aria-live="polite">
+              Welcome back! Loading your account...
+            </p>
+          ) : null}
+        </form>
+      </CardContent>
+    </Card>
   );
 }

--- a/src/app/(transactions)/account/sign-out-button.tsx
+++ b/src/app/(transactions)/account/sign-out-button.tsx
@@ -2,24 +2,27 @@
 
 import { useTransition } from "react";
 
+import { Button } from "@/components/ui/button";
+
 import { signOutAccountAction } from "./account-actions";
 
 export function AccountSignOutButton() {
   const [pending, startTransition] = useTransition();
 
   return (
-    <button
+    <Button
       type="button"
+      variant="ghost"
       onClick={() =>
         startTransition(async () => {
           await signOutAccountAction();
           window.location.href = "/account?signedOut=1";
         })
       }
-      className="text-sm font-semibold text-amber-600 hover:text-amber-700 disabled:opacity-50"
+      className="h-11 px-5 text-primary hover:bg-primary/10"
       disabled={pending}
     >
       {pending ? "Signing out..." : "Sign out"}
-    </button>
+    </Button>
   );
 }

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,0 +1,26 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export type CheckboxProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <input
+        ref={ref}
+        type="checkbox"
+        className={cn(
+          "peer h-5 w-5 shrink-0 rounded-md border-2 border-border bg-background transition",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+          "focus-visible:ring-offset-background checked:border-transparent checked:bg-primary checked:text-primary-foreground",
+          "disabled:cursor-not-allowed disabled:opacity-60",
+          "[accent-color:var(--color-primary)]",
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+Checkbox.displayName = "Checkbox";


### PR DESCRIPTION
## Summary
- refresh the account experience with shadcn-inspired cards, hero metrics, and richer recent activity lists
- rebuild account forms to use shared UI components and add a styled marketing opt-in surface
- redesign the offers page with shadcn cards, audience badges, and upgraded empty states plus add a reusable checkbox component

## Testing
- npm run lint *(fails: missing @eslint/eslintrc package in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3b15f91c083218cc77790596a7485