### PR TITLE
Fix sign-in form reset on async submit

### DIFF
--- a/src/app/(transactions)/account/sign-in-form.tsx
+++ b/src/app/(transactions)/account/sign-in-form.tsx
@@ -18,7 +18,8 @@ export function AccountSignInForm() {
 
   async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    const formData = new FormData(event.currentTarget);
+    const form = event.currentTarget;
+    const formData = new FormData(form);
     const email = String(formData.get("email") ?? "").trim();
     const password = String(formData.get("password") ?? "");
 
@@ -38,7 +39,7 @@ export function AccountSignInForm() {
       return;
     }
 
-    event.currentTarget.reset();
+    form.reset();
     setSignedIn(true);
     setPending(false);
     router.replace("/account?welcome=1");


### PR DESCRIPTION
## Summary
- capture the sign-in form element before awaiting the authentication request
- reset the stored form element after a successful sign-in to avoid null currentTarget errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3b3c9719483219cc1b5a835ca1ead