### PR TITLE
Adopt orange-forward styling across the UI

### DIFF
--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -70,7 +70,7 @@ function HeroSection() {
             ))}
           </dl>
         </div>
-        <Card className="flex-1 border-white/70 bg-white/80 shadow-xl backdrop-blur">
+        <Card className="flex-1 border-primary/15 bg-white/90 shadow-xl shadow-primary/15 backdrop-blur">
           <CardHeader className="p-8 pb-4">
             <Badge variant="outline" className="border-primary/40 text-primary">
               Chef&apos;s note
@@ -122,7 +122,7 @@ async function PromotionsSection() {
       </header>
       <div className="mt-10 grid gap-6 md:grid-cols-2 xl:grid-cols-3">
         {promotions.slice(0, 3).map((promotion) => (
-          <Card key={promotion.id} className="border-border/70 bg-card/90">
+          <Card key={promotion.id} className="border-primary/15 bg-white/95">
             <CardHeader className="pb-4">
               <Badge variant="outline" className="border-primary/30 text-xs text-primary">
                 {promotion.audience === "CATERING" ? "Catering" : "Signature experience"}
@@ -140,7 +140,7 @@ async function PromotionsSection() {
               </CardContent>
             ) : null}
             {promotion.ctaUrl ? (
-              <CardFooter className="bg-muted/40">
+              <CardFooter className="bg-primary/5">
                 <Link href={promotion.ctaUrl} className={cn(buttonClasses({ variant: "link" }), "text-primary")}>
                   {promotion.ctaLabel ?? "Reserve now"}
                 </Link>
@@ -177,7 +177,7 @@ async function LocationsSection() {
       </header>
       <div className="mt-10 grid gap-6 md:grid-cols-2 xl:grid-cols-3">
         {locations.map((location) => (
-          <Card key={location.id} className="border-border/70 bg-card/95">
+          <Card key={location.id} className="border-primary/15 bg-white/95">
             <CardHeader className="pb-4">
               <CardTitle className="text-2xl">{location.name}</CardTitle>
               <CardDescription>
@@ -191,17 +191,17 @@ async function LocationsSection() {
                 <p className="font-medium text-foreground">Dining style</p>
                 <p>Chef-led tasting menus with vegetarian pairings available.</p>
               </div>
-              <Separator className="bg-border/60" />
+              <Separator className="bg-primary/15" />
               <div>
                 <p className="font-medium text-foreground">Today&apos;s service</p>
                 <p>Open from 12:00 – 22:00 with walk-in lounge from 16:00.</p>
               </div>
             </CardContent>
-            <CardFooter className="bg-muted/30">
+            <CardFooter className="bg-primary/5">
               <Link href={`/locations/${location.slug}`} className={cn(buttonClasses({ variant: "link" }), "text-primary")}>
                 View details
               </Link>
-              <Button variant="ghost" size="sm" className="text-xs text-muted-foreground hover:text-foreground">
+              <Button variant="ghost" size="sm" className="text-xs text-primary/80 hover:text-primary">
                 Map &amp; directions
               </Button>
             </CardFooter>
@@ -230,8 +230,8 @@ function CraftSection() {
 
   return (
     <section className="mx-auto max-w-6xl px-6 pb-20">
-      <div className="relative overflow-hidden rounded-[2.5rem] border border-border/70 bg-gradient-to-r from-secondary/60 via-background to-background p-[1px] shadow-xl">
-        <div className="rounded-[2.45rem] bg-white/80 px-8 py-16 backdrop-blur md:px-14">
+      <div className="relative overflow-hidden rounded-[2.5rem] border border-primary/15 bg-gradient-to-r from-primary/20 via-white to-white p-[1px] shadow-[0_26px_70px_rgba(255,125,0,0.16)]">
+        <div className="rounded-[2.45rem] bg-white/85 px-8 py-16 backdrop-blur md:px-14">
           <div className="mx-auto max-w-3xl text-center">
             <Badge variant="subtle" className="mx-auto mb-4 w-fit bg-accent/10 text-accent">
               The Kiisi craft
@@ -247,9 +247,9 @@ function CraftSection() {
             {items.map((item) => (
               <div
                 key={item.title}
-                className="rounded-3xl border border-border/60 bg-white/70 p-6 text-left shadow-sm backdrop-blur transition hover:-translate-y-1 hover:shadow-md"
+                className="rounded-3xl border border-primary/15 bg-white/80 p-6 text-left shadow-sm backdrop-blur transition hover:-translate-y-1 hover:shadow-[0_18px_40px_rgba(255,125,0,0.18)]"
               >
-                <div className="mb-4 h-12 w-12 rounded-2xl bg-primary/10" />
+                <div className="mb-4 h-12 w-12 rounded-2xl bg-primary/15" />
                 <h3 className="text-xl font-semibold text-foreground">{item.title}</h3>
                 <p className="mt-3 text-sm leading-6 text-muted-foreground">{item.description}</p>
               </div>

--- a/src/app/(transactions)/account/account-form.tsx
+++ b/src/app/(transactions)/account/account-form.tsx
@@ -28,7 +28,7 @@ export function AccountForm({ profile, locations }: AccountFormProps) {
 
   return (
     <form action={(formData) => startTransition(() => action(formData))}>
-      <Card className="border-none bg-card shadow-xl shadow-primary/10">
+      <Card className="border-primary/15 bg-white/95 shadow-xl shadow-primary/10">
         <CardHeader className="space-y-1 pb-4">
           <CardTitle className="text-2xl">Profile details</CardTitle>
           <CardDescription>
@@ -84,7 +84,7 @@ export function AccountForm({ profile, locations }: AccountFormProps) {
             />
           </div>
 
-          <div className="flex items-start gap-3 rounded-2xl border border-border/60 bg-muted/50 p-4">
+          <div className="flex items-start gap-3 rounded-2xl border border-primary/15 bg-primary/5 p-4">
             <Checkbox id="marketingOptIn" name="marketingOptIn" defaultChecked={profile.marketingOptIn} />
             <div className="space-y-1 text-sm">
               <Label htmlFor="marketingOptIn" className="font-medium">
@@ -107,7 +107,7 @@ export function AccountForm({ profile, locations }: AccountFormProps) {
             </div>
           ) : null}
         </CardContent>
-        <div className="flex flex-col gap-3 border-t border-border/60 bg-muted/40 px-8 py-6 text-sm text-muted-foreground md:flex-row md:items-center md:justify-between">
+        <div className="flex flex-col gap-3 border-t border-primary/15 bg-primary/5 px-8 py-6 text-sm text-muted-foreground md:flex-row md:items-center md:justify-between">
           <p>{pending ? "Saving your preferences..." : "Changes apply immediately across Kiisi experiences."}</p>
           <Button type="submit" className="h-11 px-6" disabled={pending}>
             {pending ? "Saving..." : "Save profile"}

--- a/src/app/(transactions)/account/page.tsx
+++ b/src/app/(transactions)/account/page.tsx
@@ -84,8 +84,8 @@ export default async function AccountPage() {
   return (
     <div className="relative mx-auto max-w-6xl space-y-10 px-6 py-12">
       <div className="pointer-events-none absolute inset-x-10 -top-12 h-64 rounded-full bg-primary/10 blur-3xl" />
-      <Card className="relative overflow-hidden border-none bg-gradient-to-br from-primary/15 via-card to-card shadow-2xl shadow-primary/20">
-        <div className="pointer-events-none absolute -right-24 top-0 h-56 w-56 rounded-full bg-accent/20 blur-3xl" />
+      <Card className="relative overflow-hidden border-primary/20 bg-gradient-to-br from-white via-primary/10 to-white shadow-[0_30px_80px_rgba(255,125,0,0.18)]">
+        <div className="pointer-events-none absolute -right-24 top-0 h-56 w-56 rounded-full bg-primary/15 blur-3xl" />
         <CardHeader className="relative z-10 flex flex-col gap-4 pb-6 md:flex-row md:items-center md:justify-between">
           <div className="space-y-3">
             <CardTitle className="text-3xl md:text-4xl">Your Kiisi account</CardTitle>
@@ -96,7 +96,7 @@ export default async function AccountPage() {
           </div>
           <AccountSignOutButton />
         </CardHeader>
-        <CardFooter className="relative z-10 grid gap-4 border-t border-white/40 bg-white/40 px-8 py-6 text-sm text-muted-foreground backdrop-blur md:grid-cols-3">
+        <CardFooter className="relative z-10 grid gap-4 border-t border-primary/20 bg-primary/5 px-8 py-6 text-sm text-muted-foreground backdrop-blur md:grid-cols-3">
           <div className="space-y-1">
             <p className="text-xs uppercase tracking-[0.24em]">Orders</p>
             <p className="text-lg font-semibold text-foreground">{recentOrders.length}</p>
@@ -122,14 +122,14 @@ export default async function AccountPage() {
           locations={locations.map((location) => ({ slug: location.slug, name: location.name }))}
         />
         <div className="space-y-6">
-          <Card className="border-none bg-card shadow-xl shadow-primary/10">
+          <Card className="border-primary/15 bg-white/95 shadow-xl shadow-primary/10">
             <CardHeader>
               <CardTitle className="text-xl">Recent orders</CardTitle>
               <CardDescription>Revisit your latest takeaway celebrations from Kiisi.</CardDescription>
             </CardHeader>
             <CardContent>
               {recentOrders.length === 0 ? (
-                <div className="flex flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-border/70 bg-muted/30 px-6 py-10 text-center text-sm text-muted-foreground">
+                <div className="flex flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-primary/20 bg-primary/5 px-6 py-10 text-center text-sm text-muted-foreground">
                   <p>No orders yet. Ready for your first takeaway feast?</p>
                 </div>
               ) : (
@@ -137,7 +137,7 @@ export default async function AccountPage() {
                   {recentOrders.map((order) => (
                     <li
                       key={order.id}
-                      className="rounded-2xl border border-border/60 bg-gradient-to-br from-card via-card to-primary/5 p-5 shadow-sm shadow-primary/10"
+                      className="rounded-2xl border border-primary/15 bg-gradient-to-br from-white via-primary/5 to-white p-5 shadow-sm shadow-primary/10"
                     >
                       <div className="flex flex-wrap items-start justify-between gap-3">
                         <div className="space-y-1">
@@ -162,14 +162,14 @@ export default async function AccountPage() {
               )}
             </CardContent>
           </Card>
-          <Card className="border-none bg-card shadow-xl shadow-primary/10">
+          <Card className="border-primary/15 bg-white/95 shadow-xl shadow-primary/10">
             <CardHeader>
               <CardTitle className="text-xl">Reservations</CardTitle>
               <CardDescription>Track your upcoming and past dining room experiences.</CardDescription>
             </CardHeader>
             <CardContent>
               {recentReservations.length === 0 ? (
-                <div className="flex flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-border/70 bg-muted/30 px-6 py-10 text-center text-sm text-muted-foreground">
+                <div className="flex flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-primary/20 bg-primary/5 px-6 py-10 text-center text-sm text-muted-foreground">
                   <p>No reservations booked yet. We would love to host you soon.</p>
                 </div>
               ) : (
@@ -177,7 +177,7 @@ export default async function AccountPage() {
                   {recentReservations.map((reservation) => (
                     <li
                       key={reservation.id}
-                      className="rounded-2xl border border-border/60 bg-gradient-to-br from-card via-card to-accent/5 p-5 shadow-sm shadow-accent/10"
+                      className="rounded-2xl border border-primary/15 bg-gradient-to-br from-white via-primary/5 to-white p-5 shadow-sm shadow-primary/10"
                     >
                       <div className="flex flex-wrap items-start justify-between gap-3">
                         <div className="space-y-1">

--- a/src/app/(transactions)/account/sign-in-form.tsx
+++ b/src/app/(transactions)/account/sign-in-form.tsx
@@ -46,7 +46,7 @@ export function AccountSignInForm() {
   }
 
   return (
-    <Card className="relative overflow-hidden border-none bg-card shadow-xl shadow-primary/10">
+    <Card className="relative overflow-hidden border-primary/20 bg-white/95 shadow-xl shadow-primary/15">
       <div className="pointer-events-none absolute -right-20 -top-20 h-48 w-48 rounded-full bg-primary/10 blur-3xl" />
       <CardHeader className="relative space-y-2 pb-2">
         <CardTitle className="text-2xl">Sign in to Kiisi</CardTitle>

--- a/src/app/(transactions)/layout.tsx
+++ b/src/app/(transactions)/layout.tsx
@@ -9,11 +9,11 @@ export default function TransactionsLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="flex min-h-screen flex-col bg-neutral-50 pb-24 text-neutral-900 md:pb-0">
+    <div className="flex min-h-screen flex-col bg-gradient-to-b from-white via-primary/5 to-white pb-24 text-foreground md:pb-0">
       <Suspense fallback={<SkeletonHeader />}>
         <SiteHeader />
       </Suspense>
-      <main className="flex-1 bg-neutral-50">{children}</main>
+      <main className="flex-1 bg-transparent">{children}</main>
       <Suspense fallback={<SkeletonFooter />}>
         <SiteFooter />
       </Suspense>

--- a/src/app/(transactions)/order/order-form.tsx
+++ b/src/app/(transactions)/order/order-form.tsx
@@ -181,7 +181,7 @@ export function OrderForm({ locations, menuItems }: OrderFormProps) {
   };
 
   return (
-    <Card className="border-border/70 bg-card/95">
+    <Card className="border-primary/15 bg-white/95">
       <form
         action={(formData) => {
           startTransition(() => {
@@ -219,14 +219,14 @@ export function OrderForm({ locations, menuItems }: OrderFormProps) {
             </div>
             <div className="grid gap-3">
               {lines.length === 0 ? (
-                <p className="rounded-2xl border border-dashed border-border/70 bg-muted/40 px-4 py-3 text-sm text-muted-foreground">
+                <p className="rounded-2xl border border-dashed border-primary/20 bg-primary/5 px-4 py-3 text-sm text-muted-foreground">
                   No menu items available right now.
                 </p>
               ) : null}
               {lines.map((line, index) => (
                 <div
                   key={line.id}
-                  className="grid gap-3 rounded-2xl border border-border/70 bg-background/60 p-4 md:grid-cols-[minmax(0,1fr)_120px_auto] md:items-end"
+                  className="grid gap-3 rounded-2xl border border-primary/15 bg-white/80 p-4 md:grid-cols-[minmax(0,1fr)_120px_auto] md:items-end"
                 >
                   <div className="grid gap-2">
                     <Label htmlFor={`menuItem-${line.id}`}>Menu item {lines.length > 1 ? index + 1 : ""}</Label>
@@ -259,6 +259,7 @@ export function OrderForm({ locations, menuItems }: OrderFormProps) {
                     <Button
                       type="button"
                       variant="ghost"
+                      className="text-primary/70 hover:text-primary"
                       size="sm"
                       onClick={() => handleRemoveLine(line.id)}
                       disabled={lines.length <= 1}
@@ -335,7 +336,7 @@ export function OrderForm({ locations, menuItems }: OrderFormProps) {
             <Textarea id="specialInstructions" name="specialInstructions" rows={3} />
           </div>
 
-          <div className="rounded-3xl border border-dashed border-border/70 bg-muted/40 px-5 py-4 text-sm text-muted-foreground">
+          <div className="rounded-3xl border border-dashed border-primary/20 bg-primary/5 px-5 py-4 text-sm text-muted-foreground">
             Service hours are enforced. Orders outside opening times will receive the next available slot or an error.
           </div>
 
@@ -359,11 +360,11 @@ export function OrderForm({ locations, menuItems }: OrderFormProps) {
             </div>
           ) : null}
         </CardContent>
-        <div className="flex items-center justify-end gap-3 border-t border-border/70 bg-muted/30 px-8 py-5">
+        <div className="flex items-center justify-end gap-3 border-t border-primary/15 bg-primary/5 px-8 py-5">
           <Button
             type="submit"
-            className="bg-transparent text-muted-foreground hover:bg-muted/60"
-            variant="ghost"
+            className="bg-white/70 text-primary hover:bg-primary/10"
+            variant="outline"
             name="intent"
             value="check"
             disabled={pending}

--- a/src/app/(transactions)/order/page.tsx
+++ b/src/app/(transactions)/order/page.tsx
@@ -20,9 +20,9 @@ export default async function OrderPage() {
 
   return (
     <div className="mx-auto max-w-5xl space-y-10 px-6 py-12">
-      <Card className="overflow-hidden border-border/70 bg-gradient-to-br from-primary/10 via-background to-background">
+      <Card className="overflow-hidden border-primary/20 bg-gradient-to-br from-white via-primary/10 to-white">
         <CardContent className="relative space-y-4 p-10">
-          <div className="pointer-events-none absolute -right-20 top-1/2 h-56 w-56 -translate-y-1/2 rounded-full bg-primary/20 blur-3xl" aria-hidden />
+          <div className="pointer-events-none absolute -right-20 top-1/2 h-56 w-56 -translate-y-1/2 rounded-full bg-primary/25 blur-3xl" aria-hidden />
           <Badge variant="outline">Pickup & dine-in</Badge>
           <h1 className="text-3xl font-semibold tracking-tight text-foreground">Place an order</h1>
           <p className="max-w-2xl text-sm text-muted-foreground">

--- a/src/app/(transactions)/reserve/page.tsx
+++ b/src/app/(transactions)/reserve/page.tsx
@@ -9,9 +9,9 @@ export default async function ReservePage() {
 
   return (
     <div className="mx-auto max-w-5xl space-y-10 px-6 py-12">
-      <Card className="overflow-hidden border-border/70 bg-gradient-to-br from-primary/10 via-background to-background">
+      <Card className="overflow-hidden border-primary/20 bg-gradient-to-br from-white via-primary/10 to-white">
         <CardContent className="relative space-y-4 p-10">
-          <div className="pointer-events-none absolute -left-24 top-1/2 h-56 w-56 -translate-y-1/2 rounded-full bg-primary/20 blur-3xl" aria-hidden />
+          <div className="pointer-events-none absolute -left-24 top-1/2 h-56 w-56 -translate-y-1/2 rounded-full bg-primary/25 blur-3xl" aria-hidden />
           <Badge variant="outline">Instant confirmation</Badge>
           <h1 className="text-3xl font-semibold tracking-tight text-foreground">Reserve a table</h1>
           <p className="max-w-2xl text-sm text-muted-foreground">

--- a/src/app/(transactions)/reserve/reservation-form.tsx
+++ b/src/app/(transactions)/reserve/reservation-form.tsx
@@ -35,7 +35,7 @@ export function ReservationForm({ locations }: ReservationFormProps) {
   const [pending, startTransition] = useTransition();
 
   return (
-    <Card className="border-border/70 bg-card/95">
+    <Card className="border-primary/15 bg-white/95">
       <form
         action={(formData) => {
           startTransition(() => action(formData));
@@ -89,7 +89,7 @@ export function ReservationForm({ locations }: ReservationFormProps) {
             <Textarea id="notes" name="notes" rows={3} />
           </div>
 
-          <div className="rounded-3xl border border-dashed border-border/70 bg-muted/40 px-5 py-4 text-sm text-muted-foreground">
+          <div className="rounded-3xl border border-dashed border-primary/20 bg-primary/5 px-5 py-4 text-sm text-muted-foreground">
             Kiisi holds reservations for 15 minutes. If your preferred slot is unavailable we will offer the nearest alternatives
             automatically.
           </div>
@@ -130,13 +130,13 @@ export function ReservationForm({ locations }: ReservationFormProps) {
             </div>
           ) : null}
         </CardContent>
-        <div className="flex flex-wrap items-center justify-between gap-3 border-t border-border/70 bg-muted/30 px-8 py-5">
+        <div className="flex flex-wrap items-center justify-between gap-3 border-t border-primary/15 bg-primary/5 px-8 py-5">
           <Button
             type="submit"
             name="intent"
             value="check"
-            variant="ghost"
-            className="bg-transparent text-muted-foreground hover:bg-muted/60"
+            variant="outline"
+            className="bg-white/70 text-primary hover:bg-primary/10"
             disabled={pending}
           >
             {pending ? "Checking…" : "Find table"}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,25 +1,25 @@
 @import "tailwindcss";
 
 :root {
-  --background: 42 47% 97%;
-  --foreground: 24 14% 12%;
-  --muted: 36 41% 92%;
-  --muted-foreground: 25 11% 36%;
+  --background: 34 64% 98%;
+  --foreground: 24 22% 14%;
+  --muted: 32 48% 94%;
+  --muted-foreground: 26 18% 36%;
   --card: 0 0% 100%;
-  --card-foreground: 24 14% 12%;
+  --card-foreground: 24 22% 14%;
   --popover: 0 0% 100%;
-  --popover-foreground: 24 14% 12%;
-  --border: 30 24% 88%;
-  --input: 30 24% 88%;
-  --primary: 26 96% 47%;
-  --primary-foreground: 45 100% 98%;
-  --secondary: 35 70% 94%;
-  --secondary-foreground: 24 16% 28%;
-  --accent: 189 75% 43%;
-  --accent-foreground: 195 100% 97%;
+  --popover-foreground: 24 22% 14%;
+  --border: 30 44% 90%;
+  --input: 30 44% 90%;
+  --primary: 26 96% 54%;
+  --primary-foreground: 38 100% 98%;
+  --secondary: 32 92% 96%;
+  --secondary-foreground: 23 32% 28%;
+  --accent: 22 90% 60%;
+  --accent-foreground: 36 100% 98%;
   --destructive: 4 88% 58%;
-  --destructive-foreground: 0 0% 98%;
-  --ring: 26 96% 47%;
+  --destructive-foreground: 0 0% 100%;
+  --ring: 26 96% 54%;
   --radius-xs: 0.75rem;
   --radius-sm: 1.1rem;
   --radius: 1.5rem;
@@ -27,25 +27,25 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: 30 20% 6%;
-    --foreground: 35 35% 96%;
-    --muted: 28 21% 16%;
-    --muted-foreground: 36 17% 70%;
-    --card: 28 18% 12%;
-    --card-foreground: 35 35% 96%;
-    --popover: 28 18% 12%;
-    --popover-foreground: 35 35% 96%;
-    --border: 28 18% 18%;
-    --input: 28 18% 18%;
-    --primary: 30 92% 63%;
-    --primary-foreground: 28 22% 8%;
-    --secondary: 22 26% 21%;
-    --secondary-foreground: 36 24% 88%;
-    --accent: 194 84% 62%;
-    --accent-foreground: 209 100% 12%;
-    --destructive: 0 86% 67%;
-    --destructive-foreground: 24 12% 10%;
-    --ring: 30 92% 63%;
+    --background: 24 34% 8%;
+    --foreground: 34 44% 94%;
+    --muted: 26 32% 18%;
+    --muted-foreground: 33 22% 76%;
+    --card: 26 28% 12%;
+    --card-foreground: 34 44% 94%;
+    --popover: 26 28% 12%;
+    --popover-foreground: 34 44% 94%;
+    --border: 26 26% 22%;
+    --input: 26 26% 22%;
+    --primary: 26 92% 62%;
+    --primary-foreground: 42 100% 97%;
+    --secondary: 24 30% 20%;
+    --secondary-foreground: 34 64% 92%;
+    --accent: 22 82% 58%;
+    --accent-foreground: 40 100% 96%;
+    --destructive: 0 86% 60%;
+    --destructive-foreground: 20 24% 8%;
+    --ring: 26 92% 62%;
   }
 }
 

--- a/src/components/navigation/navigation-bar.tsx
+++ b/src/components/navigation/navigation-bar.tsx
@@ -50,15 +50,15 @@ export function NavigationBar({ primary, secondary, mobile }: NavigationBarProps
 
   return (
     <>
-      <header className="sticky top-0 z-50 border-b border-border/60 bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+      <header className="sticky top-0 z-50 border-b border-primary/10 bg-white/90 shadow-[0_8px_24px_rgba(255,125,0,0.08)] backdrop-blur supports-[backdrop-filter]:bg-white/80">
         <div
-          className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-primary/50 to-transparent"
+          className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-primary/60 to-transparent"
           aria-hidden
         />
         <div className="relative mx-auto flex h-20 w-full max-w-6xl items-center justify-between gap-4 px-6">
           <Link
             href="/"
-            className="group inline-flex items-center gap-4 rounded-full border border-transparent bg-background/40 px-3 py-1 transition hover:border-border/70 hover:bg-background/70"
+            className="group inline-flex items-center gap-4 rounded-full border border-primary/10 bg-white/70 px-3 py-1 shadow-[0_6px_20px_rgba(255,125,0,0.12)] transition hover:border-primary/20 hover:bg-white"
           >
             <span className="relative inline-flex h-12 w-12 shrink-0 items-center justify-center overflow-hidden rounded-full bg-gradient-to-br from-primary via-primary/80 to-primary/60 text-sm font-black uppercase tracking-[0.35em] text-primary-foreground shadow-[0_4px_12px_rgba(0,0,0,0.12)] transition-transform group-hover:scale-105">
               <span className="absolute inset-0 rounded-full border border-white/40 opacity-0 transition-opacity group-hover:opacity-100" />
@@ -84,10 +84,10 @@ export function NavigationBar({ primary, secondary, mobile }: NavigationBarProps
                       variant,
                       size: "sm",
                     }),
-                    "h-10 rounded-full px-5 ring-1 ring-border/60",
+                    "h-10 rounded-full px-5 shadow-sm",
                     active
-                      ? "ring-2 ring-primary/30"
-                      : "border-primary/50 text-primary hover:border-primary/60 hover:bg-primary/10 hover:text-primary",
+                      ? "shadow-[0_12px_30px_rgba(255,125,0,0.28)]"
+                      : "border border-primary/40 bg-white/80 text-primary hover:border-primary/60 hover:bg-primary/10",
                   )}
                 >
                   <span>{link.label}</span>
@@ -98,7 +98,7 @@ export function NavigationBar({ primary, secondary, mobile }: NavigationBarProps
           </nav>
 
           <div className="hidden items-center gap-3 lg:flex">
-            <Separator orientation="vertical" className="h-6" />
+            <Separator orientation="vertical" className="h-6 bg-primary/20" />
             <nav aria-label="Secondary" className="flex items-center gap-2 text-xs">
               {secondary.map((link) => {
                 const active = isActivePath(pathname ?? "/", link.href);
@@ -109,7 +109,9 @@ export function NavigationBar({ primary, secondary, mobile }: NavigationBarProps
                     aria-current={active ? "page" : undefined}
                     className={cn(
                       "rounded-full px-2.5 py-1.5 transition",
-                      active ? "bg-muted text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground",
+                      active
+                        ? "bg-primary/10 text-primary shadow-sm"
+                        : "text-muted-foreground hover:text-primary",
                     )}
                   >
                     {link.label}
@@ -123,7 +125,7 @@ export function NavigationBar({ primary, secondary, mobile }: NavigationBarProps
             type="button"
             variant="ghost"
             size="icon"
-            className="relative h-10 w-10 md:hidden"
+            className="relative h-10 w-10 rounded-2xl border border-primary/20 bg-white/80 text-primary shadow-sm md:hidden"
             aria-expanded={mobileOpen}
             aria-label={mobileOpen ? "Close navigation" : "Open navigation"}
             onClick={() => setMobileOpen((value) => !value)}
@@ -151,7 +153,7 @@ export function NavigationBar({ primary, secondary, mobile }: NavigationBarProps
         </div>
 
         {mobileOpen ? (
-          <div className="border-t border-border/60 bg-background/95 shadow-lg md:hidden" role="dialog" aria-modal>
+          <div className="border-t border-primary/15 bg-white/95 shadow-[0_20px_40px_rgba(255,125,0,0.12)] md:hidden" role="dialog" aria-modal>
             <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-6 py-6">
               <div className="grid gap-2">
                 {primary.map((link) => {
@@ -163,12 +165,12 @@ export function NavigationBar({ primary, secondary, mobile }: NavigationBarProps
                       href={link.href}
                       aria-current={active ? "page" : undefined}
                       className={cn(
-                        "flex items-center justify-between rounded-2xl border border-border/60 px-4 py-3 text-sm font-semibold transition",
+                        "flex items-center justify-between rounded-2xl border border-transparent px-4 py-3 text-sm font-semibold transition",
                         active
-                          ? "bg-primary text-primary-foreground shadow-sm"
+                          ? "bg-primary text-primary-foreground shadow-[0_12px_30px_rgba(255,125,0,0.24)]"
                           : emphasize
-                            ? "bg-primary/10 text-primary hover:bg-primary/20"
-                            : "bg-muted/40 text-foreground hover:bg-muted",
+                            ? "border-primary/30 bg-primary/10 text-primary hover:bg-primary/20"
+                            : "border-primary/10 bg-white/70 text-foreground hover:border-primary/30 hover:bg-primary/10",
                       )}
                     >
                       <span>{link.label}</span>
@@ -181,10 +183,10 @@ export function NavigationBar({ primary, secondary, mobile }: NavigationBarProps
               {secondary.length ? (
                 <div className="space-y-3">
                   <div className="flex items-center justify-between">
-                    <span className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+                    <span className="text-xs font-semibold uppercase tracking-[0.12em] text-primary/70">
                       Discover
                     </span>
-                    <Separator className="flex-1" />
+                    <Separator className="flex-1 bg-primary/20" />
                   </div>
                   <div className="grid gap-2">
                     {secondary.map((link) => {
@@ -197,8 +199,8 @@ export function NavigationBar({ primary, secondary, mobile }: NavigationBarProps
                           className={cn(
                             "rounded-2xl px-4 py-3 text-sm font-medium transition",
                             active
-                              ? "bg-muted text-foreground"
-                              : "text-muted-foreground hover:bg-muted/60 hover:text-foreground",
+                              ? "bg-primary/10 text-primary"
+                              : "text-muted-foreground hover:bg-primary/10 hover:text-primary",
                           )}
                         >
                           {link.label}
@@ -217,7 +219,7 @@ export function NavigationBar({ primary, secondary, mobile }: NavigationBarProps
       {mobile.length ? (
         <nav
           aria-label="Mobile navigation"
-          className="fixed inset-x-0 bottom-0 z-40 border-t border-border/70 bg-background/95 pb-[env(safe-area-inset-bottom)] pb-2 pt-1 shadow-[0_-6px_18px_rgba(15,23,42,0.08)] backdrop-blur md:hidden"
+          className="fixed inset-x-0 bottom-0 z-40 border-t border-primary/20 bg-white/95 pb-[env(safe-area-inset-bottom)] pb-2 pt-1 shadow-[0_-8px_24px_rgba(255,125,0,0.12)] backdrop-blur md:hidden"
         >
           <div className="mx-auto flex max-w-6xl items-stretch justify-between px-2 py-1">
             {mobile.map((link) => {
@@ -230,8 +232,8 @@ export function NavigationBar({ primary, secondary, mobile }: NavigationBarProps
                   className={cn(
                     "flex flex-1 flex-col items-center gap-1 rounded-2xl px-3 py-2 text-xs font-medium transition",
                     active
-                      ? "bg-primary/10 text-primary"
-                      : "text-muted-foreground hover:text-foreground",
+                      ? "bg-primary/15 text-primary"
+                      : "text-muted-foreground hover:text-primary",
                   )}
                 >
                   <span>{link.label}</span>
@@ -243,7 +245,7 @@ export function NavigationBar({ primary, secondary, mobile }: NavigationBarProps
                   <span
                     className={cn(
                       "mt-1 h-1 w-8 rounded-full transition",
-                      active ? "bg-primary" : "bg-transparent",
+                      active ? "bg-primary" : "bg-primary/10",
                     )}
                     aria-hidden
                   />

--- a/src/components/navigation/site-header.tsx
+++ b/src/components/navigation/site-header.tsx
@@ -17,20 +17,20 @@ export async function SiteHeader() {
 
 export function SiteFooter() {
   return (
-    <footer className="border-t border-neutral-200 bg-neutral-50">
-      <div className="mx-auto flex max-w-6xl flex-col gap-4 px-6 py-8 text-sm text-neutral-500 md:flex-row md:items-center md:justify-between">
+    <footer className="border-t border-primary/15 bg-gradient-to-br from-white via-primary/5 to-white">
+      <div className="mx-auto flex max-w-6xl flex-col gap-4 px-6 py-8 text-sm text-muted-foreground md:flex-row md:items-center md:justify-between">
         <div>
-          <p className="font-semibold text-neutral-900">Restoran Kiisi</p>
-          <p className="text-xs">Seasonal cuisine from Tallinn Old Town.</p>
+          <p className="font-semibold text-foreground">Restoran Kiisi</p>
+          <p className="text-xs text-primary/80">Seasonal cuisine from Tallinn Old Town.</p>
         </div>
         <div className="flex flex-wrap gap-4 text-xs">
-          <Link href="/privacy" className="hover:text-neutral-900">
+          <Link href="/privacy" className="transition hover:text-primary">
             Privacy
           </Link>
-          <Link href="/terms" className="hover:text-neutral-900">
+          <Link href="/terms" className="transition hover:text-primary">
             Terms
           </Link>
-          <Link href="/contact" className="hover:text-neutral-900">
+          <Link href="/contact" className="transition hover:text-primary">
             Contact
           </Link>
         </div>

--- a/src/components/navigation/skeletons.tsx
+++ b/src/components/navigation/skeletons.tsx
@@ -1,21 +1,21 @@
-﻿export function SkeletonHeader() {
+export function SkeletonHeader() {
   return (
-    <div className="animate-pulse border-b border-neutral-200 bg-white/60">
+    <div className="animate-pulse border-b border-primary/15 bg-white/70">
       <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
-        <div className="h-6 w-32 rounded bg-neutral-200" />
+        <div className="h-6 w-32 rounded bg-primary/10" />
         <div className="hidden gap-4 md:flex">
-          <div className="h-4 w-16 rounded bg-neutral-200" />
-          <div className="h-4 w-20 rounded bg-neutral-200" />
-          <div className="h-4 w-14 rounded bg-neutral-200" />
+          <div className="h-4 w-16 rounded bg-primary/10" />
+          <div className="h-4 w-20 rounded bg-primary/10" />
+          <div className="h-4 w-14 rounded bg-primary/10" />
         </div>
         <div className="hidden gap-3 lg:flex">
-          <div className="h-3 w-12 rounded bg-neutral-200" />
-          <div className="h-3 w-10 rounded bg-neutral-200" />
+          <div className="h-3 w-12 rounded bg-primary/10" />
+          <div className="h-3 w-10 rounded bg-primary/10" />
         </div>
       </div>
-      <div className="flex items-center justify-around border-t border-neutral-200 bg-white px-4 py-3 md:hidden">
+      <div className="flex items-center justify-around border-t border-primary/10 bg-white px-4 py-3 md:hidden">
         {[...Array(4)].map((_, index) => (
-          <div key={index} className="h-3 w-10 rounded bg-neutral-200" />
+          <div key={index} className="h-3 w-10 rounded bg-primary/10" />
         ))}
       </div>
     </div>
@@ -25,13 +25,13 @@
 export function SkeletonSection() {
   return (
     <div className="mx-auto flex max-w-6xl flex-col gap-6 px-6 py-12">
-      <div className="h-8 w-48 rounded bg-neutral-200" />
+      <div className="h-8 w-48 rounded bg-primary/10" />
       <div className="grid gap-6 md:grid-cols-3">
         {[...Array(3)].map((_, index) => (
-          <div key={index} className="space-y-4 rounded-lg border border-neutral-200 bg-white p-6">
-            <div className="h-4 w-32 rounded bg-neutral-200" />
-            <div className="h-3 w-full rounded bg-neutral-200" />
-            <div className="h-3 w-3/4 rounded bg-neutral-200" />
+          <div key={index} className="space-y-4 rounded-3xl border border-primary/15 bg-white/80 p-6">
+            <div className="h-4 w-32 rounded bg-primary/10" />
+            <div className="h-3 w-full rounded bg-primary/10" />
+            <div className="h-3 w-3/4 rounded bg-primary/10" />
           </div>
         ))}
       </div>
@@ -41,13 +41,13 @@ export function SkeletonSection() {
 
 export function SkeletonFooter() {
   return (
-    <div className="border-t border-neutral-200 bg-neutral-50">
-      <div className="mx-auto flex max-w-6xl flex-col gap-4 px-6 py-8 text-sm text-neutral-500 md:flex-row md:items-center md:justify-between">
-        <div className="h-4 w-32 rounded bg-neutral-200" />
+    <div className="border-t border-primary/15 bg-gradient-to-br from-white via-primary/5 to-white">
+      <div className="mx-auto flex max-w-6xl flex-col gap-4 px-6 py-8 text-sm text-muted-foreground md:flex-row md:items-center md:justify-between">
+        <div className="h-4 w-32 rounded bg-primary/10" />
         <div className="flex gap-4">
-          <div className="h-3 w-12 rounded bg-neutral-200" />
-          <div className="h-3 w-12 rounded bg-neutral-200" />
-          <div className="h-3 w-12 rounded bg-neutral-200" />
+          <div className="h-3 w-12 rounded bg-primary/10" />
+          <div className="h-3 w-12 rounded bg-primary/10" />
+          <div className="h-3 w-12 rounded bg-primary/10" />
         </div>
       </div>
     </div>

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -4,9 +4,9 @@ import { cn } from "@/lib/utils";
 type BadgeVariant = "default" | "outline" | "subtle";
 
 const variantStyles: Record<BadgeVariant, string> = {
-  default: "bg-primary/15 text-primary ring-1 ring-primary/20",
-  outline: "border border-border text-muted-foreground",
-  subtle: "bg-muted text-muted-foreground",
+  default: "bg-primary/15 text-primary ring-1 ring-primary/30",
+  outline: "border border-primary/30 text-primary",
+  subtle: "bg-secondary text-secondary-foreground",
 };
 
 export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,13 +5,15 @@ type ButtonVariant = "default" | "secondary" | "outline" | "ghost" | "link";
 type ButtonSize = "sm" | "default" | "lg" | "icon";
 
 const baseStyles =
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-full text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-60 focus-visible:ring-offset-background";
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-full text-sm font-semibold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-60 focus-visible:ring-offset-background";
 
 const variantStyles: Record<ButtonVariant, string> = {
-  default: "bg-primary text-primary-foreground shadow-sm hover:bg-primary/90",
-  secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-  outline: "border border-input bg-background text-foreground hover:bg-muted hover:text-foreground",
-  ghost: "text-muted-foreground hover:bg-muted hover:text-foreground",
+  default:
+    "bg-primary text-primary-foreground shadow-[0_12px_32px_rgba(255,125,0,0.28)] hover:bg-primary/90",
+  secondary: "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
+  outline:
+    "border border-primary/40 bg-background text-primary shadow-sm hover:border-primary/60 hover:bg-primary/10",
+  ghost: "text-primary hover:bg-primary/10",
   link: "text-primary underline-offset-4 hover:text-primary/80 hover:underline",
 };
 

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ export function Card({ className, ...props }: CardProps) {
   return (
     <div
       className={cn(
-        "group relative overflow-hidden rounded-3xl border border-border/80 bg-card shadow-lg shadow-black/5 transition hover:-translate-y-1 hover:shadow-xl",
+        "group relative overflow-hidden rounded-[2.5rem] border border-primary/15 bg-card/95 shadow-[0_20px_50px_rgba(255,125,0,0.14)] backdrop-blur transition hover:-translate-y-1 hover:shadow-[0_26px_60px_rgba(255,125,0,0.18)]",
         className,
       )}
       {...props}
@@ -42,5 +42,5 @@ export function CardDescription({ className, ...props }: CardDescriptionProps) {
 export interface CardFooterProps extends HTMLAttributes<HTMLDivElement> {}
 
 export function CardFooter({ className, ...props }: CardFooterProps) {
-  return <div className={cn("flex items-center justify-between gap-2 border-t border-border/60 bg-muted/30 px-8 py-5", className)} {...props} />;
+  return <div className={cn("flex items-center justify-between gap-2 border-t border-primary/15 bg-primary/5 px-8 py-5", className)} {...props} />;
 }


### PR DESCRIPTION
## Summary
- refresh the global palette to a warm white-and-orange scheme and update shared UI primitives (buttons, badges, cards, skeletons)
- restyle the navigation header/footer and marketing sections with orange gradients and highlights
- align reservation, ordering, and account flows with the new palette for consistent emphasis on key actions

## Testing
- npm run lint *(fails: cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68e3f18c9bc883218bdea6f3fb50aef8