### PR TITLE
Expand seeded menu selections

### DIFF
--- a/scripts/seed-content.ts
+++ b/scripts/seed-content.ts
@@ -98,43 +98,194 @@ async function seedMenu(locationId: string) {
 
   const categories = [starters, mains, desserts];
 
-  const kiisiBurger = await prisma.menuItem.create({
-    data: {
+  const itemsData = [
+    {
       slug: "kiisi-burger",
       categoryId: mains.id,
       name: "Kiisi Burger",
       description: "Dry-aged beef, brioche, and house pickles",
       price: new Prisma.Decimal("15.90"),
       dietaryTags: ["gluten"],
-      spiceLevel: "MEDIUM",
+      spiceLevel: "MEDIUM" as const,
     },
-  });
-
-  const mushroomSoup = await prisma.menuItem.create({
-    data: {
+    {
       slug: "forest-mushroom-soup",
       categoryId: starters.id,
       name: "Forest Mushroom Soup",
       description: "Wild mushrooms, truffle cream, rye crumbs",
       price: new Prisma.Decimal("8.50"),
       dietaryTags: ["vegetarian"],
-      spiceLevel: "MILD",
+      spiceLevel: "MILD" as const,
     },
-  });
-
-  const cloudBerry = await prisma.menuItem.create({
-    data: {
+    {
       slug: "cloudberry-parfait",
       categoryId: desserts.id,
       name: "Cloudberry Parfait",
       description: "Nordic berries, white chocolate",
       price: new Prisma.Decimal("6.90"),
       dietaryTags: ["gluten-free"],
-      spiceLevel: "MILD",
+      spiceLevel: "MILD" as const,
     },
-  });
+    {
+      slug: "smoked-trout-toast",
+      categoryId: starters.id,
+      name: "Smoked Trout Toast",
+      description: "Juniper-smoked trout, whipped butter, seed crumble",
+      price: new Prisma.Decimal("12.40"),
+      dietaryTags: ["pescatarian"],
+      spiceLevel: "MILD" as const,
+    },
+    {
+      slug: "charred-beet-salad",
+      categoryId: starters.id,
+      name: "Charred Beet Salad",
+      description: "Coal-roasted beets, dill yogurt, toasted buckwheat",
+      price: new Prisma.Decimal("11.20"),
+      dietaryTags: ["vegan", "gluten-free"],
+      spiceLevel: "MILD" as const,
+    },
+    {
+      slug: "spruce-tip-broth",
+      categoryId: starters.id,
+      name: "Spruce Tip Broth",
+      description: "Clarified vegetable broth infused with spruce tips",
+      price: new Prisma.Decimal("9.80"),
+      dietaryTags: ["vegan"],
+      spiceLevel: "MILD" as const,
+    },
+    {
+      slug: "rye-crusted-goat-cheese",
+      categoryId: starters.id,
+      name: "Rye-Crusted Goat Cheese",
+      description: "Warm chèvre, fermented lingonberry glaze",
+      price: new Prisma.Decimal("10.50"),
+      dietaryTags: ["vegetarian"],
+      spiceLevel: "MILD" as const,
+    },
+    {
+      slug: "sea-buckthorn-ceviche",
+      categoryId: starters.id,
+      name: "Sea Buckthorn Ceviche",
+      description: "Baltic whitefish cured in citrus and sea buckthorn",
+      price: new Prisma.Decimal("13.60"),
+      dietaryTags: ["pescatarian", "gluten-free"],
+      spiceLevel: "MEDIUM" as const,
+    },
+    {
+      slug: "herb-crusted-lamb",
+      categoryId: mains.id,
+      name: "Herb-Crusted Lamb",
+      description: "Estonian lamb saddle, smoked garlic jus",
+      price: new Prisma.Decimal("24.50"),
+      dietaryTags: ["dairy"],
+      spiceLevel: "MEDIUM" as const,
+    },
+    {
+      slug: "celeriac-steak",
+      categoryId: mains.id,
+      name: "Celeriac Steak",
+      description: "Roasted celeriac, hazelnut praline, fermented mushroom",
+      price: new Prisma.Decimal("18.90"),
+      dietaryTags: ["vegan", "gluten-free"],
+      spiceLevel: "MILD" as const,
+    },
+    {
+      slug: "baltic-cod-fillet",
+      categoryId: mains.id,
+      name: "Baltic Cod Fillet",
+      description: "Poached cod, fennel pollen butter, sea herbs",
+      price: new Prisma.Decimal("23.00"),
+      dietaryTags: ["pescatarian", "gluten-free"],
+      spiceLevel: "MILD" as const,
+    },
+    {
+      slug: "wild-boar-ragout",
+      categoryId: mains.id,
+      name: "Wild Boar Ragout",
+      description: "Hand-cut pappardelle, juniper braised wild boar",
+      price: new Prisma.Decimal("21.50"),
+      dietaryTags: ["gluten"],
+      spiceLevel: "MEDIUM" as const,
+    },
+    {
+      slug: "barley-risotto",
+      categoryId: mains.id,
+      name: "Barley Risotto",
+      description: "Creamed pearl barley, roasted root vegetables, aged cheese",
+      price: new Prisma.Decimal("17.40"),
+      dietaryTags: ["vegetarian"],
+      spiceLevel: "MILD" as const,
+    },
+    {
+      slug: "smoked-duck-breast",
+      categoryId: mains.id,
+      name: "Smoked Duck Breast",
+      description: "Cherrywood-smoked duck, charred cabbage, lingon glaze",
+      price: new Prisma.Decimal("22.70"),
+      dietaryTags: [],
+      spiceLevel: "MEDIUM" as const,
+    },
+    {
+      slug: "rye-honey-layer-cake",
+      categoryId: desserts.id,
+      name: "Rye Honey Layer Cake",
+      description: "Spiced rye sponge, sour cream caramel",
+      price: new Prisma.Decimal("8.10"),
+      dietaryTags: ["gluten"],
+      spiceLevel: "MILD" as const,
+    },
+    {
+      slug: "sea-buckthorn-sorbet",
+      categoryId: desserts.id,
+      name: "Sea Buckthorn Sorbet",
+      description: "Tart sea buckthorn, candied citrus peel",
+      price: new Prisma.Decimal("7.20"),
+      dietaryTags: ["vegan", "gluten-free"],
+      spiceLevel: "MILD" as const,
+    },
+    {
+      slug: "juniper-chocolate-torte",
+      categoryId: desserts.id,
+      name: "Juniper Chocolate Torte",
+      description: "Flourless chocolate torte, juniper Chantilly",
+      price: new Prisma.Decimal("8.80"),
+      dietaryTags: ["nuts", "gluten-free"],
+      spiceLevel: "MILD" as const,
+    },
+    {
+      slug: "birch-sap-panna-cotta",
+      categoryId: desserts.id,
+      name: "Birch Sap Panna Cotta",
+      description: "Vanilla panna cotta, birch sap gel, sorrel oil",
+      price: new Prisma.Decimal("7.90"),
+      dietaryTags: ["gluten-free"],
+      spiceLevel: "MILD" as const,
+    },
+    {
+      slug: "caramelized-bread-pudding",
+      categoryId: desserts.id,
+      name: "Caramelized Bread Pudding",
+      description: "Toasted brioche, sea salt caramel, vanilla anglaise",
+      price: new Prisma.Decimal("7.50"),
+      dietaryTags: ["gluten"],
+      spiceLevel: "MILD" as const,
+    },
+    {
+      slug: "salted-caramel-kama",
+      categoryId: desserts.id,
+      name: "Salted Caramel Kama",
+      description: "Whipped kama mousse, smoked salt caramel, honeycomb",
+      price: new Prisma.Decimal("7.30"),
+      dietaryTags: ["vegetarian"],
+      spiceLevel: "MILD" as const,
+    },
+  ];
 
-  const items = [kiisiBurger, mushroomSoup, cloudBerry];
+  const items = [] as Array<Awaited<ReturnType<typeof prisma.menuItem.create>>>;
+  for (const data of itemsData) {
+    const item = await prisma.menuItem.create({ data });
+    items.push(item);
+  }
 
   for (const category of categories) {
     await prisma.locationMenuCategory.create({


### PR DESCRIPTION
## Summary
- expand the seed script to create fourteen additional menu dishes across starters, mains, and desserts
- link all seeded menu items to the default location so ordering and menu pages surface the full list

## Testing
- npm test *(fails: vitest: not found)*
- npm run lint *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68e3f93c39e08321b3383a97d9ecc8b2