### PR TITLE
Add Vercel deployment configuration and documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Core database connections (PlanetScale)
+DATABASE_URL="mysql://USERNAME:PASSWORD@HOST/DATABASE?sslaccept=strict"
+DIRECT_DATABASE_URL="mysql://USERNAME:PASSWORD@HOST/DATABASE?sslaccept=strict"
+
+# NextAuth secret is used for credential hashing and JWT encryption
+NEXTAUTH_SECRET="replace-with-strong-random-secret"
+
+# Public URL of the production deployment (required by NextAuth)
+NEXTAUTH_URL="https://restoran-kiisi.vercel.app"
+
+# Optional: toggle ordering experience during incidents
+# ORDER_FORCE_CLOSED="true"

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 
 ## Deploy on Vercel
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+1. Duplicate `.env.example` and supply production credentials for PlanetScale and NextAuth secrets.
+2. Connect the repository to [Vercel](https://vercel.com/import) and import the project using the default Next.js build command (`npm run build`).
+3. Add the environment variables from your `.env` file to the Vercel project.
+4. Run `npx prisma migrate deploy --schema=prisma/schema.prisma` against the production database before the first deploy.
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+The [`docs/deployment/vercel.md`](docs/deployment/vercel.md) guide walks through the full production setup, including database provisioning, environment variables, and verification steps.

--- a/docs/deployment/vercel.md
+++ b/docs/deployment/vercel.md
@@ -1,0 +1,85 @@
+# Vercel Deployment Guide
+
+This guide documents the production rollout process for Restoran Kiisi on [Vercel](https://vercel.com/). It assumes you already have a GitHub repository for the application and access to the PlanetScale database defined in `prisma/schema.prisma`.
+
+## Prerequisites
+
+- Vercel account with permission to create projects and environment variables.
+- PlanetScale MySQL database provisioned in an EU region (e.g. `eu-central`), with credentials for both pooled (use in app) and direct connections.
+- Node.js 20.x and npm 10.x locally for running migrations or verifying builds.
+
+## 1. Prepare environment variables
+
+1. Copy `.env.example` to `.env`.
+2. Update the placeholders with real values from PlanetScale and your secret manager:
+   - `DATABASE_URL` – Prisma client connection string (PlanetScale pooled).
+   - `DIRECT_DATABASE_URL` – Direct connection string used for migrations.
+   - `NEXTAUTH_SECRET` – 32+ character random string. You can generate one with `openssl rand -base64 32`.
+   - `NEXTAUTH_URL` – Production URL (e.g. `https://restoran-kiisi.vercel.app`).
+   - Optionally define `ORDER_FORCE_CLOSED=true` when you need to stop online ordering temporarily.
+3. Commit **only** `.env.example`. Never commit secrets.
+
+## 2. Run database migrations
+
+Before the first deploy (and whenever Prisma schema changes), run migrations against PlanetScale from your local machine or CI environment:
+
+```bash
+npm install
+npx prisma migrate deploy --schema=prisma/schema.prisma
+```
+
+Seed data is available to populate demo content:
+
+```bash
+npm run seed:content
+npm run seed:profile
+```
+
+(Seeds should target non-production environments.)
+
+## 3. Create the Vercel project
+
+1. Push your repository to GitHub.
+2. In Vercel, click **New Project** and import the repository.
+3. Vercel detects the Next.js framework automatically. Keep the defaults:
+   - Install Command: `npm install`
+   - Build Command: `npm run build`
+   - Output Directory: `.vercel/output`
+4. Set the deployment region to `fra1` (Frankfurt) to keep runtime close to the PlanetScale EU database. This is configured in `vercel.json` but can also be set in the Vercel UI under **Settings → Functions**.
+
+## 4. Configure environment variables in Vercel
+
+1. In the project dashboard, open **Settings → Environment Variables**.
+2. Add the same keys and values from your local `.env` file.
+3. For `NEXTAUTH_URL`, set environment-specific values:
+   - Production: `https://your-domain`.
+   - Preview: `https://<branch>-<project>.vercel.app`.
+4. Click **Save** and redeploy when prompted.
+
+## 5. Trigger the first deployment
+
+1. Merge your changes to the default branch.
+2. Vercel builds automatically. You can also trigger a deployment manually with `vercel --prod` if using the CLI.
+3. Wait for the build to complete and verify the deployment logs. Next.js server actions under `app/(transactions)` run on the Node.js runtime; marketing pages use the Edge network for low-latency caching.
+
+## 6. Post-deployment validation
+
+- Visit `/` and `/menu` to confirm static marketing pages render via Edge.
+- Visit `/order` and `/account` to validate transactional flows. Ensure orders persist in PlanetScale.
+- Confirm logs and traces arrive in Vercel Observability (configured via `instrumentation.ts`).
+- If marketing pages show stale data, run `npm run revalidate:hours` locally and redeploy.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| Build fails with Prisma errors | Missing `DATABASE_URL`/`DIRECT_DATABASE_URL` or Prisma schema migrations not applied | Double-check env vars and run `prisma migrate deploy` |
+| Authentication fails in production | `NEXTAUTH_SECRET` missing or mismatch between environments | Rotate `NEXTAUTH_SECRET` and redeploy |
+| Orders close outside business hours | `LocationHours` data missing or `ORDER_FORCE_CLOSED` set to `true` | Seed data / toggle flag |
+| Slow transactional routes | Deployment running outside EU region | Verify `preferredRegion` on layouts and `regions` in `vercel.json` |
+
+## Ongoing maintenance
+
+- Rotate secrets every 90 days.
+- Monitor uptime via Vercel checks and custom metrics described in `docs/ops-runbook.md`.
+- Use the `ORDER_FORCE_CLOSED` flag during incidents to pause new orders while keeping marketing pages online.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
     "name": "3",
     "version": "0.1.0",
     "private": true,
+    "engines": {
+        "node": "^20"
+    },
     "scripts": {
         "dev": "next dev --turbopack",
         "build": "next build --turbopack",

--- a/src/app/(marketing)/layout.tsx
+++ b/src/app/(marketing)/layout.tsx
@@ -1,7 +1,10 @@
-﻿import { Suspense } from "react";
+import { Suspense } from "react";
 
 import { SiteFooter, SiteHeader } from "@/components/navigation/site-header";
 import { SkeletonFooter, SkeletonHeader } from "@/components/navigation/skeletons";
+
+export const runtime = "edge";
+export const preferredRegion = "fra1";
 
 export default function MarketingLayout({
   children,

--- a/src/app/(transactions)/layout.tsx
+++ b/src/app/(transactions)/layout.tsx
@@ -1,7 +1,10 @@
-﻿import { Suspense } from "react";
+import { Suspense } from "react";
 
 import { SiteFooter, SiteHeader } from "@/components/navigation/site-header";
 import { SkeletonFooter, SkeletonHeader } from "@/components/navigation/skeletons";
+
+export const runtime = "nodejs";
+export const preferredRegion = "fra1";
 
 export default function TransactionsLayout({
   children,

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "installCommand": "npm install",
+  "buildCommand": "npm run build",
+  "regions": ["fra1"]
+}


### PR DESCRIPTION
## Summary
- add a `.env.example`, Vercel project configuration, and Node 20 engine hint to align the app with the intended hosting environment
- document production rollout in `docs/deployment/vercel.md` and surface the quick-start steps in the README
- set explicit runtime/region hints for marketing (edge) and transactional (node) layouts to match the hosting plan

## Testing
- npm run lint *(fails: missing `@eslint/eslintrc` dependency in the workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68e405d9d2c88321ac2525f6a2eaa20f