### PR TITLE
fix: run marketing pages on node runtime

### DIFF
--- a/src/app/(marketing)/layout.tsx
+++ b/src/app/(marketing)/layout.tsx
@@ -3,7 +3,7 @@ import { Suspense } from "react";
 import { SiteFooter, SiteHeader } from "@/components/navigation/site-header";
 import { SkeletonFooter, SkeletonHeader } from "@/components/navigation/skeletons";
 
-export const runtime = "edge";
+export const runtime = "nodejs";
 export const preferredRegion = "fra1";
 
 export default function MarketingLayout({


### PR DESCRIPTION
## Summary
- switch the marketing layout runtime to `nodejs` so Prisma-backed navigation rendering can execute without edge runtime errors

## Testing
- npm run lint *(fails: cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68e409815b888321958e58f475324c55